### PR TITLE
Improve hashing mechanism

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/psf/black
-  rev: 22.12.0
+  rev: 23.1.0
   hooks:
   - id: black
 - repo: https://github.com/PyCQA/flake8
@@ -19,7 +19,7 @@ repos:
   hooks:
   - id: flake8
 - repo: https://github.com/PyCQA/isort
-  rev: 5.11.2
+  rev: 5.12.0
   hooks:
   - id: isort
 - repo: https://github.com/asottile/pyupgrade  # update python syntax

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.8.2] - 2022-12-14
+
+### Fixed
+- Arg hashes and combo hashes attempting to write to parameters registry while in `--parallel-mode`.
+
+### Removed
+- Old dataclasses dependency. (Only used pre 3.6.)
+
+
+
+
 ## [0.8.1] - 2022-09-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## [unreleased]
 
 ### Changed
@@ -14,11 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   completely ignoring parameters as part of their hash, by setting their hashing
   function to `None`.
 - Arguments whose value is `None` are not included as part of the hash.
-
-
-
-
-## [unreleased]
 
 ### Fixed
 - Store full distributed run creating a full store folder for every distributed process.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Changed
+- Argument hashing to allow user to specify `hashing_functions` on their
+  parameter dataclasses. This allows them to (optionally) provide a function
+  for each individual parameter that will return a custom value to be hashed
+  rather than simply the default string representation. This also allows
+  completely ignoring parameters as part of their hash, by setting their hashing
+  function to `None`.
+- Arguments whose value is `None` are not included as part of the hash.
+
+
+
 
 ## [0.8.2] - 2022-12-14
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![PyPI version](https://badge.fury.io/py/curifactory.svg)](https://badge.fury.io/py/curifactory)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/curifactory.svg)](https://anaconda.org/conda-forge/curifactory)
 [![tests](https://github.com/ORNL/curifactory/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/ORNL/curifactory/actions/workflows/tests.yml)
 
 Curifactory is a library and CLI tool designed to help organize and manage

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+# Publishing Checklist
+
+1. Run `pytest`
+2. Update version in `curifactory/__init__.py`
+3. Update changelog (`CHANGELOG.md`)
+4. Generate documentation in `sphinx` directory with `make html` (if doc updates)
+5. Apply documentation `scripts/apply-docs` (if doc updates)
+6. Commit
+7. Push to github
+8. Publish to pypi `scripts/build`
+9. Tag release on github

--- a/curifactory/__init__.py
+++ b/curifactory/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 from curifactory.args import ExperimentArgs
 from curifactory.caching import Lazy
+from curifactory.hashing import set_hash_functions
 from curifactory.manager import ArtifactManager
 from curifactory.procedure import Procedure
 from curifactory.record import Record

--- a/curifactory/__init__.py
+++ b/curifactory/__init__.py
@@ -13,4 +13,4 @@ from curifactory.staging import (
     stage,
 )
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/curifactory/args.py
+++ b/curifactory/args.py
@@ -40,9 +40,27 @@ class ExperimentArgs:
     """Whether to overwrite pre-cached values. Curifactory automatically sets this based
         on command line flags."""
 
+    hash_representations: Dict[str, Union[None, Callable]] = field(
+        default_factory=dict, repr=False
+    )
+    """Dictionary of parameter names in the dataclass where you can provide functions
+        that return a unique/consistent representation for each parameter to use as
+        the value for hashing.  Setting these allow control over what counts as a
+        cache miss/cache hit. Sane defaults are applied to any parameters that don't
+        have a representation function specified here. (see ``hashing.get_parameter_hash_value``)
+
+        Any function provided is expected to take self (the entire args instance) and
+        the value of the named parameter to be hashed.
+
+        You can also provide ``None`` for any parameters in order to exclude their value
+        from the hash entirely. (This is useful for operational arguments e.g. the number
+        of GPU's or processes to run on, where you would not want changing that to invalidate
+        the existing cached values.)
+    """
+
     # NOTE: may be able to take parent classes' hashing functions into account as well
     # https://stackoverflow.com/questions/10091957/get-parent-class-name
-    hashing_functions: Dict[str, Union[None, Callable]] = field(
+    hash_representations: Dict[str, Union[None, Callable]] = field(
         default_factory=dict, repr=False
     )
     """Assigning these allows overriding how the hash for a specific argument is computed.

--- a/curifactory/args.py
+++ b/curifactory/args.py
@@ -1,34 +1,9 @@
 """Contains the parent dataclass ExperimentArgs, containing run-specific config params."""
 
-import hashlib
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from typing import Callable, Dict, Union
 
-
-# TODO: (3/3/2023) - should this just be a static function on ExperimentArgs?
-def set_hash_functions(**kwargs):
-    """Convenience function for easily setting the hashing_functions dictionary
-    with the appropriate dataclass field. Parameters passed to this function should
-    be the same as the parameter name in the args class itself.
-
-    Example:
-        .. code-block:: python
-
-            from dataclasses import dataclass
-            from curifactory import ExperimentArgs
-            from curifactory.args import set_hash_functions
-
-            @dataclass
-            class Args(ExperimentArgs):
-                a: int = 0
-                b: int = 0
-
-                hashing_functions: dict = set_hash_functions(
-                    a = lambda self, obj: str(a)
-                    b = None  # this means that b will _not be included in the hash_.
-                )
-    """
-    return field(default_factory=lambda: dict(**kwargs), repr=False)
+from curifactory import hashing
 
 
 @dataclass
@@ -65,82 +40,18 @@ class ExperimentArgs:
     """Whether to overwrite pre-cached values. Curifactory automatically sets this based
         on command line flags."""
 
-    hashing_functions: Dict[str, Union[None, Callable]] = None
+    # NOTE: may be able to take parent classes' hashing functions into account as well
+    # https://stackoverflow.com/questions/10091957/get-parent-class-name
+    hashing_functions: Dict[str, Union[None, Callable]] = field(
+        default_factory=dict, repr=False
+    )
     """Assigning these allows overriding how the hash for a specific argument is computed.
         Every key should be assigned a value of either None or a function that takes self
         (the entire args instance) and the value of the named parameter to be hashed."""
 
-    def args_hash(self, dry: bool = False):
-        """If dry, just output the "code" that will be run to compute the hash"""
-        blacklist = [
-            "hash",
-            "overwrite",
-            "hashing_functions",
-        ]  # curifactory experimentargs things we know we don't want
-        hashes = {}
+    # TODO: implement __eq__ based on args_hash
 
-        # TODO: probably need a try/except here, iirc non-picklable things fail because of an asdict somewhere?
-        hashing_dict = asdict(self)
-        for key, value in hashing_dict.items():
-            # skip things we apriori know we don't want included
-            if key in blacklist:
-                if dry:
-                    hashes[key] = f"SKIPPED: curifactory blacklist: {blacklist}"
-                continue
-
-            # first check if we've specified how to handle the hash
-            if key in self.hashing_functions:
-                if self.hashing_functions[key] is None:
-                    if dry:
-                        hashes[key] = "SKIPPED: set to None in hashing_functions"
-                    continue
-                # TODO: will need to have several types of hashing functions to handle what is getting passed in?
-                if dry:
-                    hashes[
-                        key
-                    ] = f"{self.hashing_functions[key]}(self, {value}) - {self.hashing_functions[key](self, value)}"
-                else:
-                    hashes[key] = self.hashing_functions[key](self, value)
-
-            # if the value of the argument itself is none, ignore it. This is so that we can default
-            # arguments to not be included without setting the hash function for it, and may allow
-            # fancier mechanisms in the future to better allow reproducing old experiments using an
-            # args class that has since been added to.
-            elif value is None:
-                if dry:
-                    hashes[key] = "SKIPPED: value is None"
-                continue
-
-            # -- some sane default hashing mechanisms --
-
-            # if it's another experiment args subclass, make sure to call its' args_hash
-            elif hasattr(value, "args_hash"):
-                hashes[key] = value.args_hash(dry)
-
-            # use the function name if it's a callable, rather than a pointer address
-            elif isinstance(value, Callable):
-                if dry:
-                    hashes[key] = f"{value}.__qualname__ - {value.__qualname__}"
-                else:
-                    hashes[key] = value.__qualname__
-
-            # otherwise just use the default representation!
-            else:
-                if dry:
-                    hashes[key] = f"repr(value) - {repr(value)}"
-                else:
-                    hashes[key] = repr(value)
-
-        if dry:
-            return hashes
-
-        hash_total = 0
-        # individual compute a hash for each item, and add the integer values up, turning the final number into a hash.
-        # this ensures that the order in which things are hashed won't change the hash as long as the values themselves
-        # are the same.
-        for hash_key, hash_value in hashes.items():
-            hash_hex = hashlib.md5(str(hash_value).encode()).hexdigest()
-            hash_total += int(hash_hex, 16)
-
-        final_hash = hex(hash_total)[2:]
-        return final_hash
+    def args_hash(self, dry=False):
+        """Convenience function to see the hash of these args that curifactory is
+        computing, or debug them with ``dry=True``."""
+        return hashing.args_hash(self, store_in_registry=False, dry=dry)

--- a/curifactory/args.py
+++ b/curifactory/args.py
@@ -1,6 +1,34 @@
 """Contains the parent dataclass ExperimentArgs, containing run-specific config params."""
 
-from dataclasses import dataclass
+import hashlib
+from dataclasses import asdict, dataclass, field
+from typing import Callable, Dict, Union
+
+
+# TODO: (3/3/2023) - should this just be a static function on ExperimentArgs?
+def set_hash_functions(**kwargs):
+    """Convenience function for easily setting the hashing_functions dictionary
+    with the appropriate dataclass field. Parameters passed to this function should
+    be the same as the parameter name in the args class itself.
+
+    Example:
+        .. code-block:: python
+
+            from dataclasses import dataclass
+            from curifactory import ExperimentArgs
+            from curifactory.args import set_hash_functions
+
+            @dataclass
+            class Args(ExperimentArgs):
+                a: int = 0
+                b: int = 0
+
+                hashing_functions: dict = set_hash_functions(
+                    a = lambda self, obj: str(a)
+                    b = None  # this means that b will _not be included in the hash_.
+                )
+    """
+    return field(default_factory=lambda: dict(**kwargs), repr=False)
 
 
 @dataclass
@@ -36,3 +64,83 @@ class ExperimentArgs:
     overwrite: bool = False
     """Whether to overwrite pre-cached values. Curifactory automatically sets this based
         on command line flags."""
+
+    hashing_functions: Dict[str, Union[None, Callable]] = None
+    """Assigning these allows overriding how the hash for a specific argument is computed.
+        Every key should be assigned a value of either None or a function that takes self
+        (the entire args instance) and the value of the named parameter to be hashed."""
+
+    def args_hash(self, dry: bool = False):
+        """If dry, just output the "code" that will be run to compute the hash"""
+        blacklist = [
+            "hash",
+            "overwrite",
+            "hashing_functions",
+        ]  # curifactory experimentargs things we know we don't want
+        hashes = {}
+
+        # TODO: probably need a try/except here, iirc non-picklable things fail because of an asdict somewhere?
+        hashing_dict = asdict(self)
+        for key, value in hashing_dict.items():
+            # skip things we apriori know we don't want included
+            if key in blacklist:
+                if dry:
+                    hashes[key] = f"SKIPPED: curifactory blacklist: {blacklist}"
+                continue
+
+            # first check if we've specified how to handle the hash
+            if key in self.hashing_functions:
+                if self.hashing_functions[key] is None:
+                    if dry:
+                        hashes[key] = "SKIPPED: set to None in hashing_functions"
+                    continue
+                # TODO: will need to have several types of hashing functions to handle what is getting passed in?
+                if dry:
+                    hashes[
+                        key
+                    ] = f"{self.hashing_functions[key]}(self, {value}) - {self.hashing_functions[key](self, value)}"
+                else:
+                    hashes[key] = self.hashing_functions[key](self, value)
+
+            # if the value of the argument itself is none, ignore it. This is so that we can default
+            # arguments to not be included without setting the hash function for it, and may allow
+            # fancier mechanisms in the future to better allow reproducing old experiments using an
+            # args class that has since been added to.
+            elif value is None:
+                if dry:
+                    hashes[key] = "SKIPPED: value is None"
+                continue
+
+            # -- some sane default hashing mechanisms --
+
+            # if it's another experiment args subclass, make sure to call its' args_hash
+            elif hasattr(value, "args_hash"):
+                hashes[key] = value.args_hash(dry)
+
+            # use the function name if it's a callable, rather than a pointer address
+            elif isinstance(value, Callable):
+                if dry:
+                    hashes[key] = f"{value}.__qualname__ - {value.__qualname__}"
+                else:
+                    hashes[key] = value.__qualname__
+
+            # otherwise just use the default representation!
+            else:
+                if dry:
+                    hashes[key] = f"repr(value) - {repr(value)}"
+                else:
+                    hashes[key] = repr(value)
+
+        if dry:
+            return hashes
+
+        hash_total = 0
+        # individual compute a hash for each item, and add the integer values up, turning the final number into a hash.
+        # this ensures that the order in which things are hashed won't change the hash as long as the values themselves
+        # are the same.
+        for hash_key, hash_value in hashes.items():
+            hash_hex = hashlib.md5(str(hash_value).encode()).hexdigest()
+            hash_total += int(hash_hex, 16)
+
+        final_hash = hex(hash_total)[2:]
+        return final_hash

--- a/curifactory/args.py
+++ b/curifactory/args.py
@@ -40,6 +40,8 @@ class ExperimentArgs:
     """Whether to overwrite pre-cached values. Curifactory automatically sets this based
         on command line flags."""
 
+    # NOTE: may be able to take parent classes' hashing functions into account as well
+    # https://stackoverflow.com/questions/10091957/get-parent-class-name
     hash_representations: Dict[str, Union[None, Callable]] = field(
         default_factory=dict, repr=False
     )
@@ -57,15 +59,6 @@ class ExperimentArgs:
         of GPU's or processes to run on, where you would not want changing that to invalidate
         the existing cached values.)
     """
-
-    # NOTE: may be able to take parent classes' hashing functions into account as well
-    # https://stackoverflow.com/questions/10091957/get-parent-class-name
-    hash_representations: Dict[str, Union[None, Callable]] = field(
-        default_factory=dict, repr=False
-    )
-    """Assigning these allows overriding how the hash for a specific argument is computed.
-        Every key should be assigned a value of either None or a function that takes self
-        (the entire args instance) and the value of the named parameter to be hashed."""
 
     # TODO: implement __eq__ based on args_hash
 

--- a/curifactory/hashing.py
+++ b/curifactory/hashing.py
@@ -1,0 +1,249 @@
+"""Utility functions for hashing args class instances."""
+
+import hashlib
+import json
+import os
+from copy import deepcopy
+from dataclasses import asdict, field
+from typing import Callable, Dict, Union
+
+
+# TODO: (3/5/2023) - allow passing in a dict directly as well
+def set_hash_functions(**kwargs):
+    """Convenience function for easily setting the hashing_functions dictionary
+    with the appropriate dataclass field. Parameters passed to this function should
+    be the same as the parameter name in the args class itself.
+
+    Example:
+        .. code-block:: python
+
+            from dataclasses import dataclass
+            from curifactory import ExperimentArgs
+            from curifactory.args import set_hash_functions
+
+            @dataclass
+            class Args(ExperimentArgs):
+                a: int = 0
+                b: int = 0
+
+                hashing_functions: dict = set_hash_functions(
+                    a = lambda self, obj: str(a)
+                    b = None  # this means that b will _not be included in the hash_.
+                )
+    """
+    return field(default_factory=lambda: dict(**kwargs), repr=False)
+
+
+def compute_args_hash(args, dry: bool = False) -> Union[str, Dict]:
+    """The actual mechanisms for calculating the hash of an ExperimentArgs class.
+
+    This function takes any overriding ``hashing_functions`` into account, otherwise
+    for any members on the dataclass it tries to go through sane defaults:
+
+    1. If the value of the member is ``None``, skip it. This allows default-ignoring
+        new parameters.
+    2. If a member is another dataclass, recursively ``compute_args_hash`` on it.
+        Note that if this is unintended functionality, and you need the default
+        dataclass ``repr`` for any reason, you can override it with the following:
+
+        .. code-block:: python
+
+            import curifactory as cf
+
+            @dataclass
+            class Args(cf.ExperimentArgs):
+                some_other_dataclass: OtherDataclass = None
+
+                hashing_functions = cf.set_hash_functions(
+                    some_other_dataclass = lambda self, obj: repr(obj)
+                )
+                ...
+
+    3. If a member is a callable, by default it might turn up a pointer address
+        (we found this occurs with torch modules), so use the ``__qualname__``
+        instead.
+    4. Otherwise just use the normal ``repr``.
+
+    Args:
+        dry (bool): Return a dictionary with each value as the "code" that will be
+            used to compute the actual md5 hash. Useful for debugging custom
+            hashing functions.
+    """
+    blacklist = [
+        "hash",
+        "overwrite",
+        "hashing_functions",
+    ]  # curifactory experimentargs things we know we don't want
+    hashes = {}
+
+    # TODO: probably need a try/except here, iirc non-picklable things fail because of an asdict somewhere?
+    hashing_dict = asdict(args)
+    for key, value in hashing_dict.items():
+        # skip things we apriori know we don't want included
+        if key in blacklist:
+            if dry:
+                hashes[key] = f"SKIPPED: curifactory blacklist: {blacklist}"
+            continue
+
+        # first check if we've specified how to handle the hash
+        if hasattr(args, "hashing_functions") and key in args.hashing_functions:
+            if args.hashing_functions[key] is None:
+                if dry:
+                    hashes[key] = "SKIPPED: set to None in hashing_functions"
+                continue
+            # TODO: will need to have several types of hashing functions to handle what is getting passed in?
+            if dry:
+                hashes[
+                    key
+                ] = f"{args.hashing_functions[key]}(args, {value}) - {args.hashing_functions[key](args, value)}"
+            else:
+                hashes[key] = args.hashing_functions[key](args, value)
+
+        # if the value of the argument itargs is none, ignore it. This is so that we can default
+        # arguments to not be included without setting the hash function for it, and may allow
+        # fancier mechanisms in the future to better allow reproducing old experiments using an
+        # args class that has since been added to.
+        elif value is None:
+            if dry:
+                hashes[key] = "SKIPPED: value is None"
+            continue
+
+        # -- some sane default hashing mechanisms --
+
+        # if it's another experiment args subclass, make sure to call its' args_hash
+        elif hasattr(value, "args_hash"):
+            hashes[key] = value.args_hash(dry)
+
+        # use the function name if it's a callable, rather than a pointer address
+        elif isinstance(value, Callable):
+            if dry:
+                hashes[key] = f"{value}.__qualname__ - {value.__qualname__}"
+            else:
+                hashes[key] = value.__qualname__
+
+        # otherwise just use the default representation!
+        else:
+            if dry:
+                hashes[key] = f"repr(value) - {repr(value)}"
+            else:
+                hashes[key] = repr(value)
+
+    if dry:
+        return hashes
+
+    hash_total = 0
+    # individually compute a hash for each item, and add the integer values up, turning the final number into a hash.
+    # this ensures that the order in which things are hashed won't change the hash as long as the values themselves
+    # are the same.
+    # TODO: (3/5/2023) I think I need to concatenate the hash_key and str(hash_value)
+    for hash_key, hash_value in hashes.items():
+        hash_hex = hashlib.md5((hash_key + str(hash_value)).encode()).hexdigest()
+        hash_total += int(hash_hex, 16)
+
+    final_hash = hex(hash_total)[2:]
+    return final_hash
+
+
+def args_hash(
+    args, store_in_registry: bool = False, registry_path: str = None, dry: bool = False
+) -> Union[str, Dict]:
+    """Returns a hex string representing the passed arguments, optionally recording
+    the arguments and hash in the params registry.
+
+    Note that this hash is computed once and then stored on the args instance. If values
+    on args instance are changed and ``args_hash`` is called again, it won't be reflected
+    in the hash.
+
+    Args:
+        args (ExperimentArgs): The argument set to hash.
+        registry_path (str): The location to keep the :code:`params_registry.json`.
+            If this is ``None``, ignore ``store_in_registry``.
+        store_in_registry (bool): Whether to update the params registry with the passed
+            arguments or not.
+        dry (bool): If this is set, don't store and instead of the hash return the
+            dictionary of "code" that will be used to hash - useful for debugging.
+
+    Returns:
+        The hash string computed from the arguments, or the dictionary of hashing functions
+        if ``dry`` is ``True``. (The output from ``compute_args_hash``)
+    """
+    if dry:
+        return compute_args_hash(args, dry=True)
+
+    if args.hash is not None:
+        hash_str = args.hash
+    else:
+        hash_str = compute_args_hash(args, dry=False)
+
+    def stringify(x):
+        # NOTE: at some point it may be worth doing fancier logic here. Objects
+        # that don't have __str__ implemented will return a string with a pointer,
+        # which will always be different regardless
+        return str(x)
+
+    # TODO: (3/5/2023) need to rethink how this will be done in light of the hashing functions.
+    if store_in_registry and registry_path is not None:
+        registry_path = os.path.join(registry_path, "params_registry.json")
+        registry = {}
+
+        if os.path.exists(registry_path):
+            with open(registry_path) as infile:
+                registry = json.load(infile)
+
+        registry[hash_str] = asdict(args)
+        with open(registry_path, "w") as outfile:
+            json.dump(registry, outfile, indent=4, default=stringify)
+
+    return hash_str
+
+
+# TODO: (3/5/2023) do I need the same default registry_path to None logic here as in args_hash?
+def add_args_combo_hash(
+    active_record, records_list, registry_path: str, store_in_registry: bool = False
+):
+    """Returns a hex string representing the the combined argument set hashes from the
+    passed records list. This is mainly used for getting a hash for an aggregate stage,
+    which may not have a meaningful argument set of its own.
+
+    Args:
+        active_record (Record): The currently in-use record (likely owned by the aggregate
+            stage.)
+        records_list (List[Record]): The list of records to include as part of the resulting
+            hash.
+        registry_path (str): The location to keep the :code:`params_registry.json`.
+        store_in_registry (bool): Whether to update the params registry with the passed
+            records or not.
+
+    Returns:
+        The hash string computed from the combined record arguments.
+    """
+
+    hashes = []
+    for agg_record in records_list:
+        if agg_record.args is not None:
+            hashes.append(agg_record.args.hash)
+        else:
+            hashes.append("None")
+    hashes = sorted(hashes)
+
+    hashes_for_key = deepcopy(hashes)
+    active_key = "None"
+    if active_record.args is not None:
+        active_key = active_record.args.hash
+    hashes_for_key.insert(0, active_key)
+
+    hash_key = str(hashes_for_key)
+    hash_str = hashlib.md5(hash_key.encode()).hexdigest()
+
+    if store_in_registry:
+        registry_path = os.path.join(registry_path, "params_registry.json")
+        registry = {}
+
+        if os.path.exists(registry_path):
+            with open(registry_path) as infile:
+                registry = json.load(infile)
+
+        registry[hash_str] = {"active": active_key, "arg_list": hashes}
+        with open(registry_path, "w") as outfile:
+            json.dump(registry, outfile, indent=4, default=lambda x: str(x))
+    return hash_str

--- a/curifactory/hashing.py
+++ b/curifactory/hashing.py
@@ -8,7 +8,6 @@ from dataclasses import asdict, field, is_dataclass
 from typing import Callable, Dict, Union
 
 
-# TODO: (3/5/2023) - allow passing in a dict directly as well
 def set_hash_functions(*args, **kwargs):
     """Convenience function for easily setting the hashing_functions dictionary
     with the appropriate dataclass field. Parameters passed to this function should
@@ -103,7 +102,6 @@ def compute_args_hash(args, dry: bool = False) -> Union[str, Dict]:
                 if dry:
                     hashes[key] = "SKIPPED: set to None in hashing_functions"
                 continue
-            # TODO: will need to have several types of hashing functions to handle what is getting passed in?
             if dry:
                 hashes[
                     key
@@ -111,7 +109,7 @@ def compute_args_hash(args, dry: bool = False) -> Union[str, Dict]:
             else:
                 hashes[key] = args.hashing_functions[key](args, value)
 
-        # if the value of the argument itargs is none, ignore it. This is so that we can default
+        # if the value of the argument is none, ignore it. This is so that we can default
         # arguments to not be included without setting the hash function for it, and may allow
         # fancier mechanisms in the future to better allow reproducing old experiments using an
         # args class that has since been added to.
@@ -149,11 +147,13 @@ def compute_args_hash(args, dry: bool = False) -> Union[str, Dict]:
     # individually compute a hash for each item, and add the integer values up, turning the final number into a hash.
     # this ensures that the order in which things are hashed won't change the hash as long as the values themselves
     # are the same.
+    # Note that we concatenate the string of the value with the hash key, otherwise if two parameters had eachother's
+    # values in another args instance, they'd compute the same hash which is decidedly not correct.
     for hash_key, hash_value in hashes.items():
         hash_hex = hashlib.md5((hash_key + str(hash_value)).encode()).hexdigest()
         hash_total += int(hash_hex, 16)
 
-    final_hash = hex(hash_total)[2:]
+    final_hash = hex(hash_total)[2:]  # don't include the "0x"
     return final_hash
 
 

--- a/curifactory/hashing.py
+++ b/curifactory/hashing.py
@@ -9,10 +9,15 @@ from typing import Callable, Dict, Union
 
 
 # TODO: (3/5/2023) - allow passing in a dict directly as well
-def set_hash_functions(**kwargs):
+def set_hash_functions(*args, **kwargs):
     """Convenience function for easily setting the hashing_functions dictionary
     with the appropriate dataclass field. Parameters passed to this function should
     be the same as the parameter name in the args class itself.
+
+    You can either call this function and pass in a dictionary with the hashing functions,
+    or pass each hashing function as a kwarg. If you pass in both a dictionary as the first
+    positional arg and specify kwargs, the kwarg hashing functions will be added to the
+    dictionary.
 
     Example:
         .. code-block:: python
@@ -31,6 +36,12 @@ def set_hash_functions(**kwargs):
                     b = None  # this means that b will _not be included in the hash_.
                 )
     """
+    if len(args) > 0:
+        if type(args[0]) != dict:
+            raise ValueError(
+                "If providing a positional arg to set_hash_functions, it must be a dictionary."
+            )
+        return field(default_factory=lambda: {**(args[0]), **kwargs}, repr=False)
     return field(default_factory=lambda: dict(**kwargs), repr=False)
 
 

--- a/curifactory/record.py
+++ b/curifactory/record.py
@@ -5,7 +5,7 @@ import copy
 import logging
 import os
 
-from curifactory import utils
+from curifactory import hashing
 from curifactory.caching import Lazy
 from curifactory.reporting import Reportable
 
@@ -85,17 +85,19 @@ class Record:
         # odd place to establish a hash that more correctly indicates a record than the args themselves (e.g. like with
         # aggregate combo hashes)
         if self.args is not None and self.args.hash is None:
-            self.args.hash = utils.args_hash(
+            self.args.hash = hashing.args_hash(
                 self.args,
-                self.manager.manager_cache_path,
-                not (self.manager.dry or self.manager.parallel_mode),
+                store_in_registry=not (self.manager.dry or self.manager.parallel_mode),
+                registry_path=self.manager.manager_cache_path,
             )
 
             if self.manager.store_entire_run:
-                utils.args_hash(
+                hashing.args_hash(
                     self.args,
-                    self.manager.get_run_output_path(),
-                    not (self.manager.dry or self.manager.parallel_mode),
+                    store_in_registry=not (
+                        self.manager.dry or self.manager.parallel_mode
+                    ),
+                    registry_path=self.manager.get_run_output_path(),
                 )
 
     def get_hash(self) -> str:
@@ -111,14 +113,14 @@ class Record:
         """Mark this record as starting with an aggregate stage, meaning the hash of all cached outputs produced
         within this record need to reflect the combo hash of all records going into it."""
         self.is_aggregate = True
-        self.combo_hash = utils.add_args_combo_hash(
+        self.combo_hash = hashing.add_args_combo_hash(
             self,
             aggregate_records,
             self.manager.manager_cache_path,
             not (self.manager.dry or self.manager.parallel_mode),
         )
         if self.manager.store_entire_run:
-            utils.add_args_combo_hash(
+            hashing.add_args_combo_hash(
                 self,
                 aggregate_records,
                 self.manager.get_run_output_path(),

--- a/curifactory/staging.py
+++ b/curifactory/staging.py
@@ -311,7 +311,7 @@ def stage(  # noqa: C901 -- TODO: will be difficult to simplify...
                 post_footprint = 0
                 if os.name != "nt":
                     post_footprint = (
-                        resource.getrusage(resource.RUSAGE_THREAD).ru_maxrss * 1024
+                        resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
                     )
                 _log_stats(
                     record,
@@ -389,7 +389,7 @@ def stage(  # noqa: C901 -- TODO: will be difficult to simplify...
             post_footprint = 0
             if os.name != "nt":
                 post_footprint = (
-                    resource.getrusage(resource.RUSAGE_THREAD).ru_maxrss * 1024
+                    resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
                 )
             post_mem_usage = psutil.Process().memory_info().rss
 
@@ -573,7 +573,7 @@ def aggregate(  # noqa: C901 -- TODO: will be difficult to simplify...
                 post_footprint = 0
                 if os.name != "nt":
                     post_footprint = (
-                        resource.getrusage(resource.RUSAGE_THREAD).ru_maxrss * 1024
+                        resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
                     )
                 _log_stats(
                     record,
@@ -647,7 +647,7 @@ def aggregate(  # noqa: C901 -- TODO: will be difficult to simplify...
             post_footprint = 0
             if os.name != "nt":
                 post_footprint = (
-                    resource.getrusage(resource.RUSAGE_THREAD).ru_maxrss * 1024
+                    resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
                 )
             post_mem_usage = psutil.Process().memory_info().rss
 

--- a/curifactory/utils.py
+++ b/curifactory/utils.py
@@ -1,6 +1,5 @@
 """ Helper and utility functions for the library. """
 
-import hashlib
 import json
 import logging
 import os
@@ -8,8 +7,6 @@ import platform
 import shutil
 import subprocess
 import sys
-from copy import deepcopy
-from dataclasses import asdict
 from typing import Dict
 
 from rich import get_console, reconfigure
@@ -402,107 +399,6 @@ def init_logging(
     # logging.getLogger("snorkel").setLevel(logging.WARNING)
     # logging.getLogger("snorkel.labeling.model").setLevel(logging.WARNING)
     # logging.getLogger("snorkel.labeling.model.logger").setLevel(logging.WARNING)
-
-
-# setting store_in_registry to true will store the hash and associated args dictionary
-# in registry json file
-def args_hash(args, registry_path: str, store_in_registry: bool = False) -> str:
-    """Returns a hex string representing the passed arguments, optionally recording
-    the arguments and hash in the params registry.
-
-    Args:
-        args (ExperimentArgs): The argument set to hash.
-        registry_path (str): The location to keep the :code:`params_registry.json`.
-        store_in_registry (bool): Whether to update the params registry with the passed
-            arguments or not.
-
-    Returns:
-        The hash string computed from the arguments.
-    """
-    if args.hash is not None:
-        hash_str = args.hash
-    else:
-        args_copy = deepcopy(args)
-
-        # get rid of parameters that shouldn't affect hash
-        args_dict = asdict(args_copy)
-        del args_dict["overwrite"]
-        del args_dict["hash"]
-
-        hash_key = str(args_dict)
-
-        hash_str = hashlib.md5(hash_key.encode()).hexdigest()
-
-    def stringify(x):
-        # NOTE: at some point it may be worth doing fancier logic here. Objects
-        # that don't have __str__ implemented will return a string with a pointer,
-        # which will always be different regardless
-        return str(x)
-
-    if store_in_registry:
-        registry_path = os.path.join(registry_path, "params_registry.json")
-        registry = {}
-
-        if os.path.exists(registry_path):
-            with open(registry_path) as infile:
-                registry = json.load(infile)
-
-        registry[hash_str] = asdict(args)
-        with open(registry_path, "w") as outfile:
-            json.dump(registry, outfile, indent=4, default=stringify)
-
-    return hash_str
-
-
-def add_args_combo_hash(
-    active_record, records_list, registry_path: str, store_in_registry: bool = False
-):
-    """Returns a hex string representing the the combined argument set hashes from the
-    passed records list. This is mainly used for getting a hash for an aggregate stage,
-    which may not have a meaningful argument set of its own.
-
-    Args:
-        active_record (Record): The currently in-use record (likely owned by the aggregate
-            stage.)
-        records_list (List[Record]): The list of records to include as part of the resulting
-            hash.
-        registry_path (str): The location to keep the :code:`params_registry.json`.
-        store_in_registry (bool): Whether to update the params registry with the passed
-            records or not.
-
-    Returns:
-        The hash string computed from the combined record arguments.
-    """
-
-    hashes = []
-    for agg_record in records_list:
-        if agg_record.args is not None:
-            hashes.append(agg_record.args.hash)
-        else:
-            hashes.append("None")
-    hashes = sorted(hashes)
-
-    hashes_for_key = deepcopy(hashes)
-    active_key = "None"
-    if active_record.args is not None:
-        active_key = active_record.args.hash
-    hashes_for_key.insert(0, active_key)
-
-    hash_key = str(hashes_for_key)
-    hash_str = hashlib.md5(hash_key.encode()).hexdigest()
-
-    if store_in_registry:
-        registry_path = os.path.join(registry_path, "params_registry.json")
-        registry = {}
-
-        if os.path.exists(registry_path):
-            with open(registry_path) as infile:
-                registry = json.load(infile)
-
-        registry[hash_str] = {"active": active_key, "arg_list": hashes}
-        with open(registry_path, "w") as outfile:
-            json.dump(registry, outfile, indent=4, default=lambda x: str(x))
-    return hash_str
 
 
 # https://stackoverflow.com/questions/19425736/how-to-redirect-stdout-and-stderr-to-logger-in-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,4 @@ psutil
 twine
 build
 rich
-
-black
-flake8
-isort
+pre-commit

--- a/test/test_hashing.py
+++ b/test/test_hashing.py
@@ -147,6 +147,61 @@ def test_composed_dataclasses_diff():
     args2 = MyExperimentArgs(others=NormalDC(d=7))
     assert args1.args_hash() != args2.args_hash()
 
+
+def test_set_hash_functions_with_kwargs():
+    """calling set_hash_functions with kwargs should set a dictionary with the
+    args as keys."""
+
+    @dataclass
+    class MyExperimentArgs(cf.ExperimentArgs):
+        a: int = 0
+        b: int = None
+
+        hashing_functions: dict = cf.set_hash_functions(a=None, b=None)
+
+    args = MyExperimentArgs()
+    assert "a" in args.hashing_functions
+    assert "b" in args.hashing_functions
+
+
+def test_set_hash_functions_with_dict_arg():
+    """calling set_hash_functions with a single dictionary should directly set
+    the hashing_functions."""
+
+    @dataclass
+    class MyExperimentArgs(cf.ExperimentArgs):
+        a: int = 0
+        b: int = None
+
+        hashing_functions: dict = cf.set_hash_functions({"a": None, "b": None})
+
+    args = MyExperimentArgs()
+    assert "a" in args.hashing_functions
+    assert "b" in args.hashing_functions
+
+
+def test_set_hash_functions_with_dict_and_kwargs():
+    """calling set_hash_functions with both a dictionary and kwargs should create
+    a merged dictionary."""
+
+    @dataclass
+    class MyExperimentArgs(cf.ExperimentArgs):
+        a: int = 0
+        b: int = None
+        c: int = 5
+
+        hashing_functions: dict = cf.set_hash_functions(
+            {"a": None, "b": None}, b="something else", c=None
+        )
+
+    args = MyExperimentArgs()
+    assert "a" in args.hashing_functions
+    assert "b" in args.hashing_functions
+    assert "c" in args.hashing_functions
+
+    # kwargs should override what was in possitional arg
+    assert args.hashing_functions["b"] is not None
+
     """Subclassing an args class with hashing functions set and including additional
     hashing functions in the subclass should add/use the hashing functions of both."""
 

--- a/test/test_hashing.py
+++ b/test/test_hashing.py
@@ -210,6 +210,24 @@ def test_set_hash_functions_with_dict_and_kwargs():
     where conflicting."""
 
 
+def test_set_hash_functions_on_args_instance():
+    """Setting the hashing functions directly on an instance of a parameter
+    set should change that parameter's hash, but not of any other instance of
+    those same parameters."""
+
+    @dataclass
+    class MyExperimentArgs(cf.ExperimentArgs):
+        a: int = 0
+        b: int = None
+        c: int = 5
+
+    args0 = MyExperimentArgs()
+    args1 = MyExperimentArgs()
+
+    args0.hashing_functions["c"] = None
+    assert args0.args_hash() != args1.args_hash()
+
+
 # TODO: (3/9/2023) I'm still unclear on if this should actually be the intended functionality
 def test_hash_stays_same_after_param_change():
     """If you hash a parameter set, and then change a parameter the hash shouldn't change."""

--- a/test/test_hashing.py
+++ b/test/test_hashing.py
@@ -16,13 +16,15 @@ def test_args_subclass_hash_includes_all_sub_params():
 
     args1 = MyExperimentArgs(name="test", a=6, b=7)
     dry_hash_dict = args1.args_hash(dry=True)
-    assert dry_hash_dict["name"] == "repr(value) - 'test'"
-    assert dry_hash_dict["a"] == "repr(value) - 6"
-    assert dry_hash_dict["b"] == "repr(value) - 7"
+    assert dry_hash_dict["name"] == ("repr(value)", "'test'")
+    assert dry_hash_dict["a"] == ("repr(value)", "6")
+    assert dry_hash_dict["b"] == ("repr(value)", "7")
 
     # make sure we correctly don't hash everything in the blacklist
     for should_skip in ["hash", "overwrite", "hashing_functions"]:
-        assert dry_hash_dict[should_skip].startswith("SKIPPED: curifactory blacklist")
+        assert dry_hash_dict[should_skip][0].startswith(
+            "SKIPPED: curifactory blacklist"
+        )
 
     # double check that different args with different params is in fact
     # a different hash
@@ -60,7 +62,9 @@ def test_none_hashing_function_same_when_vals_diff():
     args1 = MyExperimentArgs()
     args2 = MyExperimentArgs(a=6)
     assert args1.args_hash() == args2.args_hash()
-    assert args1.args_hash(dry=True)["a"] == "SKIPPED: set to None in hashing_functions"
+    assert (
+        args1.args_hash(dry=True)["a"][0] == "SKIPPED: set to None in hashing_functions"
+    )
 
 
 def test_none_value_not_hashed():
@@ -84,7 +88,7 @@ def test_none_value_not_hashed():
     args2 = MyExperimentArgs2()
 
     assert args1.args_hash() == args2.args_hash()
-    assert args1.args_hash(dry=True)["b"] == "SKIPPED: value is None"
+    assert args1.args_hash(dry=True)["b"][0] == "SKIPPED: value is None"
 
 
 def test_parameter_name_included_in_hash():
@@ -121,9 +125,9 @@ def test_custom_hashing_composed_dataclasses():
     args1 = MyExperimentArgs()
     args2 = MyExperimentArgs(others=NormalDC(d=7))
     assert args1.args_hash() == args2.args_hash()
-    assert type(args1.args_hash(True)["others"]) == dict
+    assert type(args1.args_hash(True)["others"][1]) == dict
     assert (
-        args1.args_hash(True)["others"]["d"]
+        args1.args_hash(True)["others"][1]["d"][0]
         == "SKIPPED: set to None in hashing_functions"
     )
 

--- a/test/test_hashing.py
+++ b/test/test_hashing.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass
 
+import pytest
+
 import curifactory as cf
 
 
@@ -208,3 +210,25 @@ def test_set_hash_functions_with_dict_and_kwargs():
     """Subclassing an args class with hashing functions set and including hashing
     functions in the subclass for the same parameter name should 'override' parent
     where conflicting."""
+
+
+@pytest.mark.skip
+def test_hash_stays_same_after_param_change():
+    """If you hash a parameter set, and then change a parameter the hash shouldn't change."""
+
+    @dataclass
+    class MyExperimentArgs(cf.ExperimentArgs):
+        a: int = 0
+        b: int = None
+        c: int = 5
+
+    args = MyExperimentArgs()
+    hash0 = args.args_hash()
+    assert args.hash == hash0
+
+    args.c = 3
+    hash1 = args.args_hash()
+    assert hash1 == hash0
+
+    """If you hash a parameter set, change a parameter, and set the .hash to `None`, the
+    hash should recompute and then change."""

--- a/test/test_hashing.py
+++ b/test/test_hashing.py
@@ -21,7 +21,7 @@ def test_args_subclass_hash_includes_all_sub_params():
     assert dry_hash_dict["b"] == ("repr(param_set.b)", "7")
 
     # make sure we correctly don't hash everything in the blacklist
-    for should_skip in ["hash", "overwrite", "hashing_functions"]:
+    for should_skip in ["hash", "overwrite", "hash_representations"]:
         assert dry_hash_dict[should_skip][0] == "SKIPPED: blacklist"
 
     # double check that different args with different params is in fact
@@ -39,7 +39,7 @@ def test_static_hashing_function_same_when_vals_diff():
         a: int = 0
         b: int = None
 
-        hashing_functions: dict = cf.set_hash_functions(a=lambda self, obj: 5)
+        hash_representations: dict = cf.set_hash_functions(a=lambda self, obj: 5)
 
     args1 = MyExperimentArgs()
     args2 = MyExperimentArgs(a=6)
@@ -55,13 +55,14 @@ def test_none_hashing_function_same_when_vals_diff():
         a: int = 0
         b: int = 5
 
-        hashing_functions: dict = cf.set_hash_functions(a=None)
+        hash_representations: dict = cf.set_hash_functions(a=None)
 
     args1 = MyExperimentArgs()
     args2 = MyExperimentArgs(a=6)
     assert args1.args_hash() == args2.args_hash()
     assert (
-        args1.args_hash(dry=True)["a"][0] == "SKIPPED: set to None in hashing_functions"
+        args1.args_hash(dry=True)["a"][0]
+        == "SKIPPED: set to None in hash_representations"
     )
 
 
@@ -112,7 +113,7 @@ def test_custom_hashing_composed_dataclasses():
         c: int = 5
         d: int = 6
 
-        hashing_functions: dict = cf.set_hash_functions(d=None)
+        hash_representations: dict = cf.set_hash_functions(d=None)
 
     @dataclass
     class MyExperimentArgs(cf.ExperimentArgs):
@@ -126,7 +127,7 @@ def test_custom_hashing_composed_dataclasses():
     assert type(args1.args_hash(True)["others"][1]) == dict
     assert (
         args1.args_hash(True)["others"][1]["d"][0]
-        == "SKIPPED: set to None in hashing_functions"
+        == "SKIPPED: set to None in hash_representations"
     )
 
 
@@ -159,27 +160,27 @@ def test_set_hash_functions_with_kwargs():
         a: int = 0
         b: int = None
 
-        hashing_functions: dict = cf.set_hash_functions(a=None, b=None)
+        hash_representations: dict = cf.set_hash_functions(a=None, b=None)
 
     args = MyExperimentArgs()
-    assert "a" in args.hashing_functions
-    assert "b" in args.hashing_functions
+    assert "a" in args.hash_representations
+    assert "b" in args.hash_representations
 
 
 def test_set_hash_functions_with_dict_arg():
     """calling set_hash_functions with a single dictionary should directly set
-    the hashing_functions."""
+    the hash_representations."""
 
     @dataclass
     class MyExperimentArgs(cf.ExperimentArgs):
         a: int = 0
         b: int = None
 
-        hashing_functions: dict = cf.set_hash_functions({"a": None, "b": None})
+        hash_representations: dict = cf.set_hash_functions({"a": None, "b": None})
 
     args = MyExperimentArgs()
-    assert "a" in args.hashing_functions
-    assert "b" in args.hashing_functions
+    assert "a" in args.hash_representations
+    assert "b" in args.hash_representations
 
 
 def test_set_hash_functions_with_dict_and_kwargs():
@@ -192,17 +193,17 @@ def test_set_hash_functions_with_dict_and_kwargs():
         b: int = None
         c: int = 5
 
-        hashing_functions: dict = cf.set_hash_functions(
+        hash_representations: dict = cf.set_hash_functions(
             {"a": None, "b": None}, b="something else", c=None
         )
 
     args = MyExperimentArgs()
-    assert "a" in args.hashing_functions
-    assert "b" in args.hashing_functions
-    assert "c" in args.hashing_functions
+    assert "a" in args.hash_representations
+    assert "b" in args.hash_representations
+    assert "c" in args.hash_representations
 
     # kwargs should override what was in possitional arg
-    assert args.hashing_functions["b"] is not None
+    assert args.hash_representations["b"] is not None
 
     """Subclassing an args class with hashing functions set and including additional
     hashing functions in the subclass should add/use the hashing functions of both."""
@@ -226,7 +227,7 @@ def test_set_hash_functions_on_args_instance():
     args0 = MyExperimentArgs()
     args1 = MyExperimentArgs()
 
-    args0.hashing_functions["c"] = None
+    args0.hash_representations["c"] = None
     assert args0.args_hash() != args1.args_hash()
 
 

--- a/test/test_hashing.py
+++ b/test/test_hashing.py
@@ -53,7 +53,7 @@ def test_none_hashing_function_same_when_vals_diff():
     @dataclass
     class MyExperimentArgs(cf.ExperimentArgs):
         a: int = 0
-        b: int = None
+        b: int = 5
 
         hashing_functions: dict = cf.set_hash_functions(a=None)
 

--- a/test/test_hashing.py
+++ b/test/test_hashing.py
@@ -1,0 +1,108 @@
+"""Ensure the args hashing works as expected."""
+
+from dataclasses import dataclass
+
+import curifactory as cf
+
+
+def test_args_subclass_hash_includes_all_sub_params():
+    """The hash of a subclass of experiment args should include all of the subclass's
+    parameters."""
+
+    @dataclass
+    class MyExperimentArgs(cf.ExperimentArgs):
+        a: int = 0
+        b: int = None
+
+    args1 = MyExperimentArgs(name="test", a=6, b=7)
+    dry_hash_dict = args1.args_hash(dry=True)
+    assert dry_hash_dict["name"] == "repr(value) - 'test'"
+    assert dry_hash_dict["a"] == "repr(value) - 6"
+    assert dry_hash_dict["b"] == "repr(value) - 7"
+
+    # make sure we correctly don't hash everything in the blacklist
+    for should_skip in ["hash", "overwrite", "hashing_functions"]:
+        assert dry_hash_dict[should_skip].startswith("SKIPPED: curifactory blacklist")
+
+    # double check that different args with different params is in fact
+    # a different hash
+    args2 = MyExperimentArgs(a=5, b=6)
+    assert args1.args_hash() != args2.args_hash()
+
+
+def test_static_hashing_function_same_when_vals_diff():
+    """Two instances of an args class where a value is different but the hashing mechanism
+    is a function that returns the same value should both have the same hash."""
+
+    @dataclass
+    class MyExperimentArgs(cf.ExperimentArgs):
+        a: int = 0
+        b: int = None
+
+        hashing_functions: dict = cf.set_hash_functions(a=lambda self, obj: 5)
+
+    args1 = MyExperimentArgs()
+    args2 = MyExperimentArgs(a=6)
+    assert args1.args_hash() == args2.args_hash()
+
+
+def test_none_hashing_function_same_when_vals_diff():
+    """An argument in an args class with a hashing function set to none should not be
+    taken into account in the output hash."""
+
+    @dataclass
+    class MyExperimentArgs(cf.ExperimentArgs):
+        a: int = 0
+        b: int = None
+
+        hashing_functions: dict = cf.set_hash_functions(a=None)
+
+    args1 = MyExperimentArgs()
+    args2 = MyExperimentArgs(a=6)
+    assert args1.args_hash() == args2.args_hash()
+    assert args1.args_hash(dry=True)["a"] == "SKIPPED: set to None in hashing_functions"
+
+
+def test_none_value_not_hashed():
+    """An args class with a parameter set to None should not have that parameter included
+    in the hash.
+
+    This also demonstrates that you can add new arguments to an old class and old experiments
+    will still run as long as the new args are defaulted to None.
+    """
+
+    @dataclass
+    class MyExperimentArgs1(cf.ExperimentArgs):
+        a: int = 0
+        b: int = None
+
+    @dataclass
+    class MyExperimentArgs2(cf.ExperimentArgs):
+        a: int = 0
+
+    args1 = MyExperimentArgs1()
+    args2 = MyExperimentArgs2()
+
+    assert args1.args_hash() == args2.args_hash()
+    assert args1.args_hash(dry=True)["b"] == "SKIPPED: value is None"
+
+
+def test_parameter_name_included_in_hash():
+    """Parameter names should be involved in hashing - two args instances where parameters are the
+    opposite of eachother should not hash to the same value."""
+
+    @dataclass
+    class MyExperimentArgs(cf.ExperimentArgs):
+        a: int = 0
+        b: int = 1
+
+    args1 = MyExperimentArgs(a=5, b=6)
+    args2 = MyExperimentArgs(a=6, b=5)
+    assert args1.args_hash() != args2.args_hash()
+
+    """Subclassing an args class with hashing functions set and including additional
+    hashing functions in the subclass should add/use the hashing functions of both."""
+
+    """Subclassing an args class with hashing functions set and including hashing
+    functions in the subclass for the same parameter name should 'override' parent
+    where conflicting."""

--- a/test/test_hashing.py
+++ b/test/test_hashing.py
@@ -2,8 +2,6 @@
 
 from dataclasses import dataclass
 
-import pytest
-
 import curifactory as cf
 
 
@@ -212,7 +210,7 @@ def test_set_hash_functions_with_dict_and_kwargs():
     where conflicting."""
 
 
-@pytest.mark.skip
+# TODO: (3/9/2023) I'm still unclear on if this should actually be the intended functionality
 def test_hash_stays_same_after_param_change():
     """If you hash a parameter set, and then change a parameter the hash shouldn't change."""
 
@@ -224,11 +222,30 @@ def test_hash_stays_same_after_param_change():
 
     args = MyExperimentArgs()
     hash0 = args.args_hash()
+    args.hash = hash0  # this emulates what run_experiment is doing.
     assert args.hash == hash0
 
     args.c = 3
     hash1 = args.args_hash()
     assert hash1 == hash0
 
+
+def test_hash_changes_after_param_change_and_hash_set_to_none():
     """If you hash a parameter set, change a parameter, and set the .hash to `None`, the
     hash should recompute and then change."""
+
+    @dataclass
+    class MyExperimentArgs(cf.ExperimentArgs):
+        a: int = 0
+        b: int = None
+        c: int = 5
+
+    args = MyExperimentArgs()
+    hash0 = args.args_hash()
+    args.hash = hash0  # this emulates what run_experiment is doing.
+    assert args.hash == hash0
+
+    args.c = 3
+    args.hash = None
+    hash1 = args.args_hash()
+    assert hash1 != hash0

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -4,7 +4,7 @@ import os
 
 from pytest_mock import mocker  # noqa: F401 -- flake8 doesn't see it's used as fixture
 
-from curifactory import ExperimentArgs, Record, aggregate, stage, utils
+from curifactory import ExperimentArgs, Record, aggregate, hashing, stage
 from curifactory.caching import Cacheable, JsonCacher, Lazy, PickleCacher
 
 
@@ -344,7 +344,7 @@ def test_stage_hash_after_aggregate_with_no_args(configured_test_manager):
 
     r0 = normal_stage(agg_stage(r0, [r1]))
 
-    combo_hash = utils.add_args_combo_hash(r0, [r1], "", False)
+    combo_hash = hashing.add_args_combo_hash(r0, [r1], "", False)
     output_path_agg = os.path.join(
         configured_test_manager.cache_path, f"test_{combo_hash}_agg_stage_testing.json"
     )

--- a/test/test_record.py
+++ b/test/test_record.py
@@ -5,7 +5,7 @@ import os
 
 from pytest_mock import mocker  # noqa: F401 -- flake8 doesn't see it's used as fixture
 
-from curifactory import ExperimentArgs, Record, aggregate, stage, utils
+from curifactory import ExperimentArgs, Record, aggregate, hashing, stage
 
 
 def test_record_sets_hash(configured_test_manager):
@@ -94,7 +94,7 @@ def test_record_gets_combo_hash_for_aggregate(configured_test_manager):
     r0 = Record(configured_test_manager, None)
     r1 = Record(configured_test_manager, ExperimentArgs(name="test"))
     r0 = agg_stage(r0, [r1])
-    combo_hash = utils.add_args_combo_hash(
+    combo_hash = hashing.add_args_combo_hash(
         r0, [r1], "", False
     )  # TODO: what about when None passed in? Empty array?
 


### PR DESCRIPTION
Closes #5 

All hashing related functionality has been moved into `hashing.py`, and the actual added mechanism for computing hashes is in the `compute_args_hash` function: https://github.com/ORNL/curifactory/blob/ac6c850430cbeea87066763f7791030e1f9c1f8e/curifactory/hashing.py#L48

The basic idea is that any subclass of `ExperimentArgs` (and any `@dataclass` instances that are composed into such a subclass) can specify a `hashing_functions` dictionary (with a helper function `set_hash_functions` implemented in that same file to avoid having to remember the weird `field` syntax that dataclasses require). In this dictionary, for each dataclass parameter the user can provide either a function that returns the value to use for hashing, or specify `None` to exclude that parameter from being used in the hash calculation.

An example:
```python
import curifactory as cf

@dataclass
class SomeArgsSubset:
    num_gpus: int = 1
    num_epochs: int = 1

    # don't include the gpu count as part of the hash (so you can re-run 
    # with varying amounts without invalidating the cache)
    hashing_functions: dict = cf.set_hash_functions(num_gpus=None)

@dataclass
class Args(cf.ExperimentArgs):
    sklearn_model_to_use: Any = None
    operational_args: SomeArgsSubset = None

    # a reminder that hashing_functions is entirely optional,
    # and even when provided, the user does not have to specify
    # for every single parameter (it will use the default on 
    # anything not explicitly given)
    hashing_functions: dict = cf.set_hash_functions(
        sklearn_model_to_use = lambda self, obj: obj.__class__
        # an example where the default repr might return a pointer address
        # we override it here to just hash based on the model class name.
        # Note that any function provided will be passed the entire dataclass
        # instance as well as the object/value being hashed.
    )

```

See the tests for some examples on what this actually looks like and a more complete specification: https://github.com/ORNL/curifactory/blob/ac6c850430cbeea87066763f7791030e1f9c1f8e/test/test_hashing.py

Some things still to be done:
- [ ] Update documentation
- [ ] Determine how to handle string/json representation put into reports
- [ ] Add some example experiments demonstrating functionality 