### PR TITLE
Caching path mechanisms and full store handling refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on `Record`'s path tracking to simply copy the cached files into the full store folder at the end of a stage.
 - Cachers' path mechanism - rather than expecting a cacher's `set_path` to be called beforehand, `save` and `load`
   should call the cacher's `get_path()`.
+- The default cachers' `save()` functions return the path that was saved to
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on `Record`'s path tracking to simply copy the cached files into the full store folder at the end of a stage.
 - Cachers' path mechanism - rather than expecting a cacher's `set_path` to be called beforehand, `save` and `load`
   should call the cacher's `get_path()`.
-- The default cachers' `save()` functions return the path that was saved to
+- The default cachers' `save()` functions return the path that was saved to.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [unreleased]
+
+### Added
+- Metadata output for every cached artifact. Alongside every output cache file will be a `[file]_metadata.json`,
+  containing information about the run that generated it, the parameters, and previous stages run in the same record.
+- `track` parameter to cachers, indicating whether the output files should be copied into a full store run folder or not.
+  (It is true by default.)
+- Optional cacher prefixes, which replaces the first part of a cached filepath name (normally the experiment name) with the provided
+  prefix. This allows cross-experiment caching (use with care!)
+- Optional cacher subdir, which places output files into the specified subdirectory in the cache/run folder (allows better organization,
+  e.g. Kedro's data engineering convention of 01_raw, 02_intermediate, etc.)
+- Allowing exact path overrides to be used by a cacher, making it cleaner to use them on the fly/outside of stages.
+
+### Changed
+- Full store cached files are now placed into an `artifacts/` subdirectory of the run folder.
+- `PickleCacher`'s extension is now correctly set to `.pkl` (we aren't actually running gzip on it.)
+- Full store runs no longer call a cacher's `save` function a second time with a new path, instead relying
+  on `Record`'s path tracking to simply copy the cached files into the full store folder at the end of a stage.
+- Cachers' path mechanism - rather than expecting a cacher's `set_path` to be called beforehand, `save` and `load`
+  should call the cacher's `get_path()`.
+
+
+
+
 ## [0.9.3] - 2023-03-21
 
 ### Fixed

--- a/curifactory/caching.py
+++ b/curifactory/caching.py
@@ -2,15 +2,21 @@
 
 This is handled through a base :code:`Cacheable` class, and each "strategy"
 cacher class extends it.
+
+Note that there are effectively two ways to use cacheables -
+# TODO finish this
 """
 
 import json
 import logging
 import os
 import pickle
+from datetime import datetime
 from typing import Dict, List, Union
 
 import pandas as pd
+
+from curifactory import hashing, utils
 
 
 class Lazy:
@@ -33,28 +39,163 @@ class Cacheable:
     """The base caching class, any caching strategy should extend this.
 
     Args:
-        extension (str): The filetype extension to add at the end of the path.
         path_override (str): Use a specific path for the cacheable, rather than
-            automatically setting it.
+            automatically setting it based on name etc.
+        name (str): The obj name to use in automatically constructing a path. If
+            a cacheable is used in stage header, this is automatically provided as
+            the output string name from the stage outputs list.
+        subdir (str): An optional string of one or more nested subdirectories to
+            prepend to the artifact filepath.  This can be used if you want to
+            subdivide cache and run artifacts into logical subsets, e.g. similar to
+            https://towardsdatascience.com/the-importance-of-layered-thinking-in-data-engineering-a09f685edc71.
+        prefix (str): An optional alternative prefix to the experiment-wide
+            prefix (either the experiment name or custom-specified experiment
+            prefix). This can be used if you want a cached object to work easier
+            across multiple experiments, rather than being experiment specific.
+            WARNING: use with caution, cross-experiment caching can mess with
+            provenance.
+        extension (str): The filetype extension to add at the end of the path.
+        record (Record): The current record this cacheable is caching under.
+            This can be used to get a copy of the current args instance and is also
+            how artifact metadata is collected.
+        track (bool): whether to include returned path in a store full copy or not.
+
+    Note:
+        It is strongly recommended that any subclasses of Cacheable take ``**kwargs`` in init and pass
+        along to ``super()``:
+
+        .. code-block:: python
+
+            class CustomCacher(cf.Cacheable):
+                def __init__(self, path_override: str = None, custom_attribute: Any = None, **kwargs):
+                    super().__init__(path_override, **kwargs)
+                    self.some_custom_attribute = custom_attribute
+
+        This allows consistent handling of paths in the parent ``get_path()`` and ``check()`` functions.
     """
 
-    def __init__(self, extension: str, path_override=None):
-        self.extension = extension
-        """str: The filetype extension to add at the end of the path."""
-        self.path = ""
-        """str: The path of the cacheable to write out."""
+    def __init__(
+        self,
+        path_override: str = None,
+        name: str = None,
+        subdir: str = None,
+        prefix: str = None,
+        extension: str = None,
+        record=None,
+        track: bool = True,
+    ):
         self.path_override = path_override
-        """str: Use a specific path for the cacheable, rather than automatically
-            setting it."""
-        if self.path_override is not None:
-            self.path = self.path_override
-        self.record = None
-        """Record: the current record this cacheable is caching under. This can be used to get a copy of the current args instance."""
+        """Use a specific path for the cacheable, rather than automatically setting it based on name etc."""
+        self.name = name
+        """The obj name to use in automatically constructing a path. If a cacheable is used in stage header, this is automatically
+        provided as the output string name from the stage outputs list."""
+        self.subdir = subdir
+        """An optional string of one or more nested subdirectories to prepend to the artifact filepath.
+        This can be used if you want to subdivide cache and run artifacts into logical subsets, e.g. similar to
+        https://towardsdatascience.com/the-importance-of-layered-thinking-in-data-engineering-a09f685edc71.  """
+        self.prefix = prefix
+        """An optional alternative prefix to the experiment-wide prefix (either the experiment name or
+        custom-specified experiment prefix). This can be used if you want a cached object to work easier across
+        multiple experiments, rather than being experiment specific. WARNING: use with caution, cross-experiment
+        caching can mess with provenance.  """
+        self.extension = extension
+        """The filetype extension to add at the end of the path. (Optional, automatically used as suffix in get_path if provided)"""
+        self.record = record
+        """The current record this cacheable is caching under. This can be used to get a copy of the current args instance and is also
+        how artifact metadata is collected."""
+        self.track = track
+        """Whether to store the artifact this cacher is used with in the run folder on store-full runs or not."""
+        self.cache_paths: List[str] = []
+        """The running list of paths this cacher is using, as appended by ``get_path``."""
+        self.metadata: Dict = None
+        """Metadata about the artifact cached with this cacheable."""
 
-    def set_path(self, path: str):
-        """Changes the :code:`path` to the passed value."""
-        self.path = path + self.extension
-        return self.path
+    def get_path(self, suffix=None) -> str:
+        """Retrieve the full filepath to use for saving and loading. This should be called in the ``save()`` and
+        ``load()`` implementations.
+
+        Args:
+            suffix (str): The suffix to append to the path. If not set, this will default to the cachable's extension.
+
+        Note:
+            If ``path_override`` is set on this cacher, this cacher _does not handle storing in the full store
+            directory._ The assumption is that either you're referring to a static external path (which doesn't make
+            sense to copy), or you're manually passing in a ``record.get_path`` in which case the record has already
+            dealt with any logic necessary to add the path to the record's ``unstored_tracked paths`` which get copied
+            over. Note also that this can be problematic for cachers that store multiple files since anything that isn't
+            the path_override won't get copied. **For multiple file cachers you should use ``name``/``subdir``/``prefix``
+            instead of setting a ``path_override``.**
+
+            # TODO: there is technically a way around this by manually adding to unstored_tracked_paths a dictionary with
+            # fully specified path (and everything else None), in which case the record resolves object name to whatever
+            # is after the last /
+        """
+        # don't deal with any additional logic if a static path was specified. (If passing in record.get_path, store-full logic
+        # is already being handled.)
+        path = None
+        if self.path_override is not None:
+            path = self.path_override
+
+            # This is to allow for metadata loading I think for a static path
+            # (if metadata exists) I think it technically also allows for save
+            # to work even based on static paths, as in it won't work without it.
+            if suffix is not None:
+                path += suffix
+        else:
+            # logic to add an extension if no suffix supplied and the object name doesn't already contain the extension
+            if suffix is None and (
+                self.extension is not None
+                and self.extension != ""
+                and not self.name.endswith(self.extension)
+            ):
+                suffix = self.extension
+            elif suffix is None:
+                suffix = ""
+
+            # TODO: error if record is none and/or name is none
+
+            obj_name = self.name + suffix
+            path = self.record.get_path(
+                obj_name, subdir=self.subdir, prefix=self.prefix, track=self.track
+            )
+        if path not in self.cache_paths:
+            self.cache_paths.append(path)
+        return path
+
+    # def get_dir(self, suffix=None) -> str:
+    #     # TODO: necessary?
+    #     pass
+
+    # def set_record(self, record):
+    #     self.record = record
+    #     self.collect_metadata()
+
+    def collect_metadata(self):
+        # TODO: error if record not set
+        self.metadata = dict(
+            artifact_generated=datetime.now().strftime(utils.TIMESTAMP_FORMAT),
+            params_hash=self.record.get_hash(),
+            params_name=self.record.args.name,
+            stage=self.record.manager.current_stage,
+            artifact_name=self.name,
+            cacher_type=str(type(self)),
+            manager_run_info=self.record.run_info,  # TODO: remove 'status' because it will never be updated here.
+            record_prior_stages=self.record.stages,
+            prior_records=self.record.input_records,  # TODO: unclear what type this is
+            params=hashing.parameters_string_hash_representation(self.record.args),
+        )
+
+    def save_metadata(self):
+        metadata_path = self.get_path("_metadata.json")
+        with open(metadata_path, "w") as outfile:
+            json.dump(self.metadata, indent=2, default=str)
+
+    def load_metadata(self) -> Dict:
+        metadata_path = self.get_path("_metadata.json")
+        if os.path.exists(metadata_path):
+            with open(metadata_path) as infile:
+                self.metadata = json.load(infile)
+        return self.metadata
 
     def check(self) -> bool:
         """Check to see if this cacheable needs to be written or not.
@@ -67,7 +208,7 @@ class Cacheable:
             don't specify to overwrite, otherwise False.
         """
         logging.debug("Searching for cached file at %s...", self.path)
-        if os.path.exists(self.path):
+        if os.path.exists(self.get_path()):
             if (
                 self.record is not None
                 and self.record.args is None
@@ -99,6 +240,8 @@ class Cacheable:
             ):
                 logging.info("Cached object '%s' found", self.path)
                 return True
+            # TODO: (3/21/2023) there's no logic correctly handling if record is just none, we
+            # probably need a separate check that determines if overwrite is set on manager?
             else:
                 logging.debug("Object found, but overwrite specified in args")
                 return False
@@ -121,9 +264,6 @@ class Cacheable:
         Note:
             Any subclass is **required** to implement this.
         """
-        raise NotImplementedError(
-            "Cacheable class does not have a save function implemented"
-        )
 
 
 class JsonCacher(Cacheable):

--- a/curifactory/caching.py
+++ b/curifactory/caching.py
@@ -210,9 +210,26 @@ class Cacheable:
             self.cache_paths.append(path)
         return path
 
-    # def get_dir(self, suffix=None) -> str:
-    #     # TODO: necessary?
-    #     pass
+    def get_dir(self, suffix=None) -> str:
+        """Returns a path for a directory with the given suffix (if provided), appropriate for use in a ``save``
+        and ``load`` function. This will create any subdirectories in the path if they don't exist.
+        """
+        path = None
+        if suffix is None:
+            suffix = ""
+
+        if self.path_override is not None:
+            path = self.path_override + suffix
+        else:
+            path = self.record.get_dir(
+                self.name + suffix,
+                subdir=self.subdir,
+                prefix=self.prefix,
+                stage_name=self.stage,
+                track=self.track,
+            )
+        os.makedirs(path, exist_ok=True)
+        return path
 
     def set_record(self, record):
         self.record = record

--- a/curifactory/caching.py
+++ b/curifactory/caching.py
@@ -179,7 +179,7 @@ class Cacheable:
             artifact_generated=datetime.now().strftime(utils.TIMESTAMP_FORMAT),
             params_hash=self.record.get_hash(),
             params_name=self.record.args.name,
-            stage=self.record.manager.current_stage,
+            stage=self.record.manager.current_stage_name,
             artifact_name=self.name,
             cacher_type=str(type(self)),
             manager_run_info=self.record.run_info,  # TODO: remove 'status' because it will never be updated here.

--- a/curifactory/caching.py
+++ b/curifactory/caching.py
@@ -73,6 +73,16 @@ class Cacheable:
                     self.some_custom_attribute = custom_attribute
 
         This allows consistent handling of paths in the parent ``get_path()`` and ``check()`` functions.
+
+        If no custom attributes are needed, also pass in *args, so path_override can be specified without
+        a kwarg:
+
+            .. code-block:: python
+
+                class CustomCacher(cf.Cacheable):
+                    def __init__(self, *args, **kwargs):
+                        super().__init__(*args, extension=".custom", **kwargs)
+
     """
 
     def __init__(
@@ -314,8 +324,8 @@ class Cacheable:
 class JsonCacher(Cacheable):
     """Dumps an object to indented JSON."""
 
-    def __init__(self, **kwargs):
-        super().__init__(extension=".json", **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, extension=".json", **kwargs)
 
     def load(self):
         with open(self.get_path()) as infile:
@@ -332,8 +342,8 @@ class JsonCacher(Cacheable):
 class PickleCacher(Cacheable):
     """Dumps an object to a pickle file."""
 
-    def __init__(self, **kwargs):
-        super().__init__(extension=".pkl", **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, extension=".pkl", **kwargs)
 
     def load(self):
         with open(self.get_path(), "rb") as infile:
@@ -448,8 +458,8 @@ class FileReferenceCacher(Cacheable):
                 return my_file_list
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(extension=".json", **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, extension=".json", **kwargs)
 
     def check(self) -> bool:
         # check the file list file exists

--- a/curifactory/caching.py
+++ b/curifactory/caching.py
@@ -346,10 +346,11 @@ class PandasJsonCacher(Cacheable):
         path_override: str = None,
         to_json_args: Dict = dict(double_precision=15),
         read_json_args: Dict = dict(),
+        **kwargs
     ):
         self.read_json_args = read_json_args
         self.to_json_args = to_json_args
-        super().__init__(".json", path_override=path_override)
+        super().__init__(path_override=path_override, extension=".json", **kwargs)
 
     def load(self):
         return pd.read_json(self.get_path(), **self.read_csv_args)

--- a/curifactory/caching.py
+++ b/curifactory/caching.py
@@ -310,9 +310,11 @@ class JsonCacher(Cacheable):
             obj = json.load(infile)
         return obj
 
-    def save(self, obj):
-        with open(self.get_path(), "w") as outfile:
+    def save(self, obj) -> str:
+        path = self.get_path()
+        with open(path, "w") as outfile:
             json.dump(obj, outfile, indent=4, default=lambda x: str(x))
+        return path
 
 
 class PickleCacher(Cacheable):
@@ -326,9 +328,11 @@ class PickleCacher(Cacheable):
             obj = pickle.load(infile)
         return obj
 
-    def save(self, obj):
-        with open(self.get_path(), "wb") as outfile:
+    def save(self, obj) -> str:
+        path = self.get_path()
+        with open(path, "wb") as outfile:
             pickle.dump(obj, outfile)
+        return path
 
 
 class PandasJsonCacher(Cacheable):
@@ -361,8 +365,10 @@ class PandasJsonCacher(Cacheable):
     def load(self):
         return pd.read_json(self.get_path(), **self.read_csv_args)
 
-    def save(self, obj):
-        obj.to_json(self.get_path(), **self.to_json_args)
+    def save(self, obj) -> str:
+        path = self.get_path()
+        obj.to_json(path, **self.to_json_args)
+        return path
 
 
 class PandasCsvCacher(Cacheable):
@@ -389,8 +395,10 @@ class PandasCsvCacher(Cacheable):
     def load(self):
         return pd.read_csv(self.get_path(), **self.read_csv_args)
 
-    def save(self, obj):
-        obj.to_csv(self.get_path(), **self.to_csv_args)
+    def save(self, obj) -> str:
+        path = self.get_path()
+        obj.to_csv(path, **self.to_csv_args)
+        return path
 
 
 class FileReferenceCacher(Cacheable):
@@ -458,6 +466,8 @@ class FileReferenceCacher(Cacheable):
             files = json.load(infile)
         return files
 
-    def save(self, files: Union[List[str], str]):
-        with open(self.get_path(), "w") as outfile:
+    def save(self, files: Union[List[str], str]) -> str:
+        path = self.get_path()
+        with open(path, "w") as outfile:
             json.dump(files, outfile, indent=4)
+        return path

--- a/curifactory/caching.py
+++ b/curifactory/caching.py
@@ -114,6 +114,8 @@ class Cacheable:
         """``collect_metadata`` uses but does not overwrite this, placing into the `extra` key
         in the actual metadata. This can be used by the cacher's save function to store additional
         information that would then be available if the 'load' function calls ``load_metadata()``."""
+        self.stage: str = None
+        """The stage associated with this cacher, if applicable."""
 
         if record is not None:
             self.set_record(record)
@@ -164,7 +166,11 @@ class Cacheable:
 
             obj_name = self.name + suffix
             path = self.record.get_path(
-                obj_name, subdir=self.subdir, prefix=self.prefix, track=self.track
+                obj_name,
+                subdir=self.subdir,
+                prefix=self.prefix,
+                stage_name=self.stage,
+                track=self.track,
             )
         if path not in self.cache_paths:
             self.cache_paths.append(path)

--- a/curifactory/manager.py
+++ b/curifactory/manager.py
@@ -26,7 +26,7 @@ class ArtifactManager:
             most relevant information and affects caching paths. If a manager is being
             used primarily from jupyter notebooks, you could for instance set this to
             be the name of the notebook.
-        store_entire_run (bool): Store/copy environment info, log, output report, and
+        store_full (bool): Store/copy environment info, log, output report, and
             all cached files in a run-specific folder (this is a --store-full run.)
         dry (bool): Setting dry to true will suppress saving any files (including logs), and will
             not update parameter stores. (It should have no effect on any files.)
@@ -65,7 +65,7 @@ class ArtifactManager:
     def __init__(
         self,
         experiment_name: str = None,
-        store_entire_run: bool = False,
+        store_full: bool = False,
         dry: bool = False,
         dry_cache: bool = False,
         custom_name: str = None,
@@ -144,7 +144,7 @@ class ArtifactManager:
 
         self.records = []
         """The list of records currently managed by this manager."""
-        self.store_entire_run: bool = store_entire_run
+        self.store_full: bool = store_full
         """Flag for whether to store/copy environment info, log, output report, and
         all cached files in a run-specific folder."""
         self.dry: bool = dry
@@ -340,7 +340,7 @@ class ArtifactManager:
             # update
             store = ManagerStore(self.manager_cache_path)
             self.run_info = store.update_run(self)
-            if self.store_entire_run:
+            if self.store_full:
                 # update relevant run_info too with new_run
                 if self.run_info is not None:
                     with open(
@@ -352,7 +352,7 @@ class ArtifactManager:
             store = ManagerStore(self.manager_cache_path)
             self.run_info = store.add_run(self)
             self.stored = True
-            if self.store_entire_run:
+            if self.store_full:
                 self.write_run_env_output()
 
     def write_run_env_output(self):
@@ -524,7 +524,7 @@ class ArtifactManager:
             self, self.reports_path, self.get_reference_name(), self.report_css_path
         )
         self.live_report_path_generated = True
-        if self.store_entire_run:
+        if self.store_full:
             reporting.run_report(
                 self, self.get_run_output_path(), "report", self.report_css_path
             )

--- a/curifactory/manager.py
+++ b/curifactory/manager.py
@@ -416,7 +416,6 @@ class ArtifactManager:
         record: Record,
         output: bool = False,
         base_path: str = None,
-        aggregate_records: List[Record] = None,
     ) -> str:
         """Get an appropriate full path/filename for a given object name and record.
 
@@ -430,9 +429,6 @@ class ArtifactManager:
             output (bool): Set this to true if the path needs to be based in a --store-full run folder.
             base_path (str): If a specific path override is needed, pass it in here. (Otherwise the
                 manager's cache_path is used.)
-            aggregate_records (List[Record]): If a list of records is passed (not none), prefix the
-                path filename with the hash of arg hashes of all the passed records. This is used for
-                paths for cached objects of aggregate stages.
 
         Returns:
             A string filepath that an object can be written to.

--- a/curifactory/manager.py
+++ b/curifactory/manager.py
@@ -410,7 +410,7 @@ class ArtifactManager:
                 non_grouped_reportables.append(reportable)
         return non_grouped_reportables
 
-    def get_path(
+    def get_artifact_path(
         self,
         obj_name: str,
         record: Record,

--- a/curifactory/manager.py
+++ b/curifactory/manager.py
@@ -416,6 +416,7 @@ class ArtifactManager:
         record: Record,
         subdir: str = None,
         prefix: str = None,
+        stage_name: str = None,
         store: bool = False,
     ) -> str:
         """Get a record-appropriate full path/filename for a given object name and record.
@@ -437,6 +438,8 @@ class ArtifactManager:
                 custom-specified experiment prefix). This can be used if you want a cached object to work easier across
                 multiple experiments, rather than being experiment specific. WARNING: use with caution, cross-experiment
                 caching can mess with provenance.
+            stage_name (str): The stage that produced an artifact. If not supplied, uses
+                the currently executing stage name.
             store (bool): Set this to true if the path needs to go into a --store-full run folder.
 
         Returns:
@@ -447,9 +450,12 @@ class ArtifactManager:
         if prefix is None:
             prefix = self._get_name()
 
+        if stage_name is None:
+            stage_name = self.current_stage_name
+
         # NOTE: at some point if we have better parallel handling in cf, we'll probably
         # want "current_stage_name" to be on the record level rather than the manager level.
-        object_path = f"{prefix}_{args_hash}_{self.current_stage_name}_{obj_name}"
+        object_path = f"{prefix}_{args_hash}_{stage_name}_{obj_name}"
 
         base_path = self.cache_path
         if store:

--- a/curifactory/record.py
+++ b/curifactory/record.py
@@ -289,6 +289,7 @@ class Record:
         dir_name_suffix: str,
         subdir: str = None,
         prefix: str = None,
+        stage_name: str = None,
         track: bool = True,
     ) -> str:
         """Returns an args-appropriate cache path with the passed name, (similar to get_path) and creates it as a directory.
@@ -302,12 +303,18 @@ class Record:
                 custom-specified experiment prefix). This can be used if you want a cached object to work easier across
                 multiple experiments, rather than being experiment specific. WARNING: use with caution, cross-experiment
                 caching can mess with provenance.
+            stage_name (str): The associated stage for a path. If not provided, the currently
+                executing stage name is used.
             track (bool): whether to include returned path in a store full copy
                 or not. This will only work if the returned path is not altered
                 by a stage before saving something to it.
         """
         dir_path = self.manager.get_artifact_path(
-            obj_name=dir_name_suffix, record=self, subdir=subdir, prefix=prefix
+            obj_name=dir_name_suffix,
+            record=self,
+            subdir=subdir,
+            prefix=prefix,
+            stage_name=stage_name,
         )
         if track:
             self.unstored_tracked_paths.append(

--- a/curifactory/record.py
+++ b/curifactory/record.py
@@ -240,7 +240,12 @@ class Record:
 
     # TODO: should also take an optional 'sub-path' and 'extension'
     def get_path(
-        self, obj_name: str, subdir: str = None, prefix: str = None, track: bool = True
+        self,
+        obj_name: str,
+        subdir: str = None,
+        prefix: str = None,
+        stage_name: str = None,
+        track: bool = True,
     ) -> str:
         """Return an args-appropriate cache path with passed object name.
 
@@ -257,14 +262,23 @@ class Record:
                 custom-specified experiment prefix). This can be used if you want a cached object to work easier across
                 multiple experiments, rather than being experiment specific. WARNING: use with caution, cross-experiment
                 caching can mess with provenance.
+            stage_name (str): The associated stage for a path. If not provided, the currently
+                executing stage name is used.
             track (bool): whether to include returned path in a store full copy
                 or not. This will only work if the returned path is not altered
                 by a stage before saving something to it.
         """
         path = self.manager.get_artifact_path(
-            obj_name=obj_name, record=self, subdir=subdir, prefix=prefix
+            obj_name=obj_name,
+            record=self,
+            subdir=subdir,
+            prefix=prefix,
+            stage_name=stage_name,
         )
         if track:
+            # TODO: (3/22/2023) do I need to also be storing stage name? These are always supposed
+            # to be handled from the current stage only anyway, so the stage name should always
+            # be the last one
             self.unstored_tracked_paths.append(
                 dict(obj_name=obj_name, subdir=subdir, prefix=prefix, path=path)
             )

--- a/curifactory/record.py
+++ b/curifactory/record.py
@@ -69,7 +69,7 @@ class Record:
         combo hash rather than the individual args hash."""
         self.combo_hash = None
         """This gets set on records that run an aggregate stage. This is set from utils.add_args_combo_hash."""
-        self.additional_tracked_paths = []
+        self.unstored_tracked_paths = []
         """Paths obtained with get_path/get_dir that should be copied to a full
         store folder. The last executed stage should manage copying anything
         listed here and then clearing it. This is a list of tuples: (obj_name,
@@ -211,7 +211,7 @@ class Record:
             obj_name=obj_name, record=self, subdir=subdir, prefix=prefix
         )
         if track:
-            self.additional_tracked_paths.append((obj_name, path))
+            self.unstored_tracked_paths.append((obj_name, path))
         return path
 
     def get_dir(
@@ -240,7 +240,7 @@ class Record:
             obj_name=dir_name_suffix, record=self, subdir=subdir, prefix=prefix
         )
         if track:
-            self.additional_tracked_paths.append((dir_name_suffix, dir_path))
+            self.unstored_tracked_paths.append((dir_name_suffix, dir_path))
 
         os.makedirs(dir_path, exist_ok=True)
         return dir_path

--- a/curifactory/record.py
+++ b/curifactory/record.py
@@ -185,7 +185,9 @@ class Record:
         return new_record
 
     # TODO: should also take an optional 'sub-path' and 'extension'
-    def get_path(self, obj_name: str, track: bool = True) -> str:
+    def get_path(
+        self, obj_name: str, subdir: str = None, prefix: str = None, track: bool = True
+    ) -> str:
         """Return an args-appropriate cache path with passed object name.
 
         This should be equivalent to what a cacher for a stage should get. Note that this
@@ -194,25 +196,49 @@ class Record:
 
         Args:
             obj_name (str): the name to associate with the object as the last part of the filename.
+            subdir (str): An optional string of one or more nested subdirectories to prepend to the artifact filepath.
+                This can be used if you want to subdivide cache and run artifacts into logical subsets, e.g. similar to
+                https://towardsdatascience.com/the-importance-of-layered-thinking-in-data-engineering-a09f685edc71.
+            prefix (str): An optional alternative prefix to the experiment-wide prefix (either the experiment name or
+                custom-specified experiment prefix). This can be used if you want a cached object to work easier across
+                multiple experiments, rather than being experiment specific. WARNING: use with caution, cross-experiment
+                caching can mess with provenance.
             track (bool): whether to include returned path in a store full copy
                 or not. This will only work if the returned path is not altered
                 by a stage before saving something to it.
         """
-        path = self.manager.get_artifact_path(obj_name=obj_name, record=self)
+        path = self.manager.get_artifact_path(
+            obj_name=obj_name, record=self, subdir=subdir, prefix=prefix
+        )
         if track:
             self.additional_tracked_paths.append((obj_name, path))
         return path
 
-    def get_dir(self, dir_name_suffix: str, track: bool = True) -> str:
+    def get_dir(
+        self,
+        dir_name_suffix: str,
+        subdir: str = None,
+        prefix: str = None,
+        track: bool = True,
+    ) -> str:
         """Returns an args-appropriate cache path with the passed name, (similar to get_path) and creates it as a directory.
 
         Args:
             dir_name_suffix (str): the name to add as a suffix to the created directory name.
+            subdir (str): An optional string of one or more nested subdirectories to prepend to the artifact filepath.
+                This can be used if you want to subdivide cache and run artifacts into logical subsets, e.g. similar to
+                https://towardsdatascience.com/the-importance-of-layered-thinking-in-data-engineering-a09f685edc71.
+            prefix (str): An optional alternative prefix to the experiment-wide prefix (either the experiment name or
+                custom-specified experiment prefix). This can be used if you want a cached object to work easier across
+                multiple experiments, rather than being experiment specific. WARNING: use with caution, cross-experiment
+                caching can mess with provenance.
             track (bool): whether to include returned path in a store full copy
                 or not. This will only work if the returned path is not altered
                 by a stage before saving something to it.
         """
-        dir_path = self.manager.get_artifact_path(obj_name=dir_name_suffix, record=self)
+        dir_path = self.manager.get_artifact_path(
+            obj_name=dir_name_suffix, record=self, subdir=subdir, prefix=prefix
+        )
         if track:
             self.additional_tracked_paths.append((dir_name_suffix, dir_path))
 

--- a/curifactory/record.py
+++ b/curifactory/record.py
@@ -198,7 +198,7 @@ class Record:
                 or not. This will only work if the returned path is not altered
                 by a stage before saving something to it.
         """
-        path = self.manager.get_path(obj_name=obj_name, record=self)
+        path = self.manager.get_artifact_path(obj_name=obj_name, record=self)
         if track:
             self.additional_tracked_paths.append((obj_name, path))
         return path
@@ -212,7 +212,7 @@ class Record:
                 or not. This will only work if the returned path is not altered
                 by a stage before saving something to it.
         """
-        dir_path = self.manager.get_path(obj_name=dir_name_suffix, record=self)
+        dir_path = self.manager.get_artifact_path(obj_name=dir_name_suffix, record=self)
         if track:
             self.additional_tracked_paths.append((dir_name_suffix, dir_path))
 

--- a/curifactory/record.py
+++ b/curifactory/record.py
@@ -111,7 +111,8 @@ class Record:
 
     def set_aggregate(self, aggregate_records):
         """Mark this record as starting with an aggregate stage, meaning the hash of all cached outputs produced
-        within this record need to reflect the combo hash of all records going into it."""
+        within this record need to reflect the combo hash of all records going into it.
+        """
         self.is_aggregate = True
         self.combo_hash = hashing.add_args_combo_hash(
             self,
@@ -183,6 +184,7 @@ class Record:
 
         return new_record
 
+    # TODO: should also take an optional 'sub-path' and 'extension'
     def get_path(self, obj_name: str, track: bool = True) -> str:
         """Return an args-appropriate cache path with passed object name.
 

--- a/curifactory/record.py
+++ b/curifactory/record.py
@@ -91,7 +91,7 @@ class Record:
                 registry_path=self.manager.manager_cache_path,
             )
 
-            if self.manager.store_entire_run:
+            if self.manager.store_full:
                 hashing.args_hash(
                     self.args,
                     store_in_registry=not (
@@ -120,7 +120,7 @@ class Record:
             self.manager.manager_cache_path,
             not (self.manager.dry or self.manager.parallel_mode),
         )
-        if self.manager.store_entire_run:
+        if self.manager.store_full:
             hashing.add_args_combo_hash(
                 self,
                 aggregate_records,

--- a/curifactory/reporting.py
+++ b/curifactory/reporting.py
@@ -411,20 +411,18 @@ def render_report_info_block(  # noqa: C901 -- TODO: yeaaaaah break it up at som
             f"<p id='run-string'>Run string: <pre>{manager.run_line}</pre></p>"
         )
 
-        if manager.store_entire_run:
-            store_entire_run_path = os.path.join(
-                manager.runs_path, manager.get_reference_name()
-            )
+        if manager.store_full:
+            cache_path = manager.get_run_output_path()
             html_lines.append(
                 f"<p><span style='color: green'><b>This run has a full cache store.</b></span> Live runs have a much lower chance of reproducing correctly than an experiment script, but you can utilize this cache with:"
-                f'<pre>manager = ArtifactManager("{manager.experiment_name}", cache_path="{store_entire_run_path}", dry_cache=True)</pre></p>'
+                f'<pre>manager = ArtifactManager("{manager.experiment_name}", cache_path="{cache_path}", dry_cache=True)</pre></p>'
             )
     else:
         html_lines.append(
             f"<p id='run-string'>Run string: <pre>{manager.run_line}</pre></p>"
         )
 
-        if manager.store_entire_run:
+        if manager.store_full:
             html_lines.append(
                 f"<p><span style='color: green'><b>This run has a full cache store.</b></span> Reproduce with:"
                 f"<pre>{manager.reproduction_line}</pre></p>"
@@ -750,7 +748,6 @@ def update_report_index(experiments_path, reports_root_dir):
                 runs.append(info)
                 experiment_name = info["experiment_name"]
                 if experiment_name not in experiment_runs:
-
                     # try to get comment on experiment
                     comment = ""
                     try:

--- a/curifactory/staging.py
+++ b/curifactory/staging.py
@@ -5,7 +5,6 @@ import copy
 import logging
 import os
 import pickle
-import shutil
 import time
 from functools import wraps
 from typing import List, Union
@@ -93,15 +92,6 @@ def stage(  # noqa: C901 -- TODO: will be difficult to simplify...
     Important:
         Any function wrapped with the stage decorator must take a Record instance as the first
         parameter, followed by the input parameters corresponding to the :code:`inputs` list.
-
-    Note:
-        Note that a wrapped function that successfully finds all cached outputs does not
-        execute, meaning any reportables that might have been output to the experiment report
-        **will not run.** This can be mitigated by putting relevant reportables in a separate
-        stage that does not cache anything. This note similarly applies to any other "side effects"
-        that might result from stage code execution. Careful design of stages should ensure
-        that the effects of stage functions are limited exclusively to the given inputs and
-        returned outputs.
 
     Args:
         inputs (List[str]): A list of variable names that this stage will need from the
@@ -281,8 +271,14 @@ def stage(  # noqa: C901 -- TODO: will be difficult to simplify...
                     cacher = cachers[i]
                     if type(cacher) == type:
                         cachers[i] = cacher()
-                    # set the active record on the cacher
-                    cachers[i].record = record
+                    # set the active record on the cacher as well as provide a default name
+                    # (the name of the output)
+                    cachers[i].set_record(record)
+                    if cachers[i].name is None and cachers[i].path_override is None:
+                        if type(outputs[i]) == Lazy:
+                            cachers[i].name = outputs[i].name
+                        else:
+                            cachers[i].name = outputs[i]
 
             # check for cached outputs and lazy load inputs if needed
             pre_cache_time_start = time.perf_counter()  # time to load from cache
@@ -291,6 +287,16 @@ def stage(  # noqa: C901 -- TODO: will be difficult to simplify...
             if cache_valid:
                 # get previous reportables if available
                 _check_cached_reportables(name, record)
+
+                # if we've hit this point, we will be returning early/not executing
+                # the stage because all outputs are found. The process of checking
+                # cached outputs should correctly add all the necessary tracked paths,
+                # so to transfer these paths into a store full run, we just need
+                # the below call
+                # NOTE: I _believe_ that we also get metadata from this because
+                # the load_metadata will have entered the metadata path already.
+                # this will need to be tested
+                record.store_tracked_paths()
 
             # check each input for Lazy objects and load them if we know we have to execute this stage
             if not cache_valid:
@@ -347,6 +353,7 @@ def stage(  # noqa: C901 -- TODO: will be difficult to simplify...
             record.manager.lock()
             _store_outputs(name, record, outputs, cachers, function_outputs)
             _store_reportables(name, record)
+            record.store_tracked_paths()
             record.manager.unlock()
             post_cache_time_end = time.perf_counter()
 
@@ -684,25 +691,25 @@ def _check_cached_outputs(stage_name, record, outputs, cachers, records=None):
     cache_valid = False
     if cachers is not None:
         # set the path for every instantiated cacher
-        paths = []
-        for index, arg in enumerate(outputs):
-            path = record.manager.get_artifact_path(str(arg), record)
-            # if cachers[index].path_override is None:
-            #     # the str(arg) will handle Lazy objects
-            #     path = record.manager.get_artifact_path(str(arg), record)
-            # elif str.endswith(cachers[index].extension, cachers[index].path_override):
-            #     # if the path override includes the extension they provided a full file name
-            #     # NOTE: this is useful if there's a static file that won't change across diff
-            #     # runs or paramsets, like an input dataset
-            #     path = cachers[index].path
-            # else:
-            #     path = record.manager.get_artifact_path(
-            #         arg,
-            #         record,
-            #         base_path=cachers[index].path,
-            #     )
-            path = cachers[index].set_path(path)
-            paths.append(path)
+        # paths = []
+        # for index, arg in enumerate(outputs):
+        #     path = record.manager.get_artifact_path(str(arg), record)
+        #     # if cachers[index].path_override is None:
+        #     #     # the str(arg) will handle Lazy objects
+        #     #     path = record.manager.get_artifact_path(str(arg), record)
+        #     # elif str.endswith(cachers[index].extension, cachers[index].path_override):
+        #     #     # if the path override includes the extension they provided a full file name
+        #     #     # NOTE: this is useful if there's a static file that won't change across diff
+        #     #     # runs or paramsets, like an input dataset
+        #     #     path = cachers[index].path
+        #     # else:
+        #     #     path = record.manager.get_artifact_path(
+        #     #         arg,
+        #     #         record,
+        #     #         base_path=cachers[index].path,
+        #     #     )
+        #     path = cachers[index].set_path(path)
+        #     paths.append(path)
 
         # NOTE: we put this here because the cachers still need to be set up
         if stage_name in record.manager.overwrite_stages or record.manager.overwrite:
@@ -711,34 +718,42 @@ def _check_cached_outputs(stage_name, record, outputs, cachers, records=None):
         # check the cache (and load into record if found)
         cache_valid = True
         function_outputs = []
-        for i in range(len(paths)):
+        for i in range(len(cachers)):
             if cachers[i].check():
                 # handle lazy objects by setting the cacher but not actually loading yet.
                 if type(outputs[i]) == Lazy:
                     outputs[i].cacher = cachers[i]
                     # we set the output to just be the Lazy instance for now
                     output = outputs[i]
+                    # TODO: (3/21/2023) is this going to correctly send to store if we
+                    # never actually call load in later stages? at least the base path will,
+                    # from load_metadata below which calls get_path, but this seems...?
                 else:
                     output = cachers[i].load()
+                cachers[i].load_metadata()
+
                 function_outputs.append(output)
                 record.state[str(outputs[i])] = output
 
-                artifact = _add_output_artifact(record, output, outputs, i)
-                artifact.file = cachers[i].path
+                artifact = _add_output_artifact(
+                    record, output, outputs, i, metadata=cachers[i].metadata
+                )
+                # TODO: (3/21/2023) possibly have "files" which would be cachers.cached_files?
+                artifact.file = cachers[i].get_path()
 
                 # copy it over to output run folder if necessary
-                if record.manager.store_full:
-                    # if we don't handle lazy separately it will literally store the lazy object.
-                    # Instead, just use the OS to copy the file over. (This avoids us having to
-                    # eat the memory costs of reloading and resaving.)
-                    previous_path = cachers[i].path
-                    cachers[i].set_path(
-                        record.manager.get_artifact_path(outputs[i], record, store=True)
-                    )
-                    if type(outputs[i]) == Lazy:
-                        shutil.copyfile(previous_path, cachers[i].path)
-                    else:
-                        cachers[i].save(output)
+                # if record.manager.store_full:
+                #     # if we don't handle lazy separately it will literally store the lazy object.
+                #     # Instead, just use the OS to copy the file over. (This avoids us having to
+                #     # eat the memory costs of reloading and resaving.)
+                #     previous_path = cachers[i].path
+                #     cachers[i].set_path(
+                #         record.manager.get_artifact_path(outputs[i], record, store=True)
+                #     )
+                #     if type(outputs[i]) == Lazy:
+                #         shutil.copyfile(previous_path, cachers[i].path)
+                #     else:
+                #         cachers[i].save(output)
             else:
                 # we found something that wasn't cached, recompute everything
                 cache_valid = False
@@ -746,18 +761,17 @@ def _check_cached_outputs(stage_name, record, outputs, cachers, records=None):
 
         # if we have the cached objects, return them right away
         if cache_valid:
-            if len(paths) == 1:
+            if len(cachers) == 1:
                 record.output = function_outputs[0]
             else:
                 record.output = tuple(function_outputs)
-            # return record
 
     return cache_valid
 
 
-def _add_output_artifact(record, object, outputs, index):
+def _add_output_artifact(record, object, outputs, index, metadata=None):
     """manage representation recording"""
-    artifact = ArtifactRepresentation(record, outputs[index], object)
+    artifact = ArtifactRepresentation(record, outputs[index], object, metadata=metadata)
     new_index = len(record.manager.artifacts)
     record.manager.artifacts.append(artifact)
     # if new_index not in record.stage_outputs[-1]:
@@ -767,13 +781,15 @@ def _add_output_artifact(record, object, outputs, index):
 
 
 def _check_cached_reportables(stage_name, record, aggregate_records=None):
-    # TODO: (3/20/2023) clean up with single line (will need to be able to pass record)
-    reportables_list_cacher = FileReferenceCacher()
-    reportables_list_cacher.record = record
-    reportables_list_cacher.set_path(
-        record.manager.get_artifact_path("reportables_file_list", record)
+    reportables_list_cacher = FileReferenceCacher(
+        name="reportables_file_list", record=record
     )
+    # reportables_list_cacher.record = record
+    # reportables_list_cacher.set_path(
+    #     record.manager.get_artifact_path("reportables_file_list", record)
+    # )
     if reportables_list_cacher.check():
+        reportables_list_cacher.load_metadata()
         paths = reportables_list_cacher.load()
         for path in paths:
             with open(path, "rb") as infile:
@@ -795,12 +811,11 @@ def _store_reportables(stage_name, record, aggregate_records=None):
     if len(reportables) == 0:
         return
 
-    # pickle each one and store it. (we'll have to handle store-full the same way as outputs below I think)
-    # STRT: (02/10/2022) like record get_dir and get_path normally, _this does not transfer into a store-full
-    # run.
-    # NOTE: so wait, this actually does transfer, but why? Is filerefcacher already handling this?
+    # pickle each one and store it.
     paths = []
-    reportables_path = record.get_dir("reportables")
+    reportables_path = record.get_dir(
+        "reportables"
+    )  # this will make sure all reportables go to full store
     for reportable in reportables:
         # make a copy of the reportable without the record, because that seems to break the mp.lock
         # when in parallel mode.
@@ -814,13 +829,13 @@ def _store_reportables(stage_name, record, aggregate_records=None):
             pickle.dump(reportable_copy, outfile)
 
     # write a cache file out containing the reportables path names.
-    # TODO: (3/20/2023) clean up with single line (will need to be able to pass record)
-    reportables_list_cacher = FileReferenceCacher()
-    reportables_list_cacher.record = record
-    reportables_list_cacher.set_path(
-        record.manager.get_artifact_path("reportables_file_list", record)
-    )
-    reportables_list_cacher.save(paths)
+    reportables_list_cacher = FileReferenceCacher(
+        name="reportables_file_list", record=record
+    ).save(paths)
+
+    # send along metadata for it, to track when the reportables were generated.
+    reportables_list_cacher.metadata["extra"]["reportables"] = True
+    reportables_list_cacher.save_metadata()
     # NOTE: unnecessary because the reportables don't get copied over anyway, see todo note above.
     # (we should get this for free without needing this code when we add extra path tracking to the manager.)
     # if record.manager.store_full:
@@ -868,9 +883,18 @@ def _store_outputs(
             and not record.manager.dry
             and not record.manager.dry_cache
         ):
-            logging.debug(f"Caching {outputs[index]} to '{cachers[index].path}'...")
+            logging.debug(
+                f"Caching {outputs[index]} to '{cachers[index].get_path()}'..."
+            )
             cachers[index].save(output)
             artifact.file = cachers[index].path
+
+            # generate and save metadata
+            # note that if we got to this point, we actually ran the stage code, so
+            # we generate _new_ metadata
+            cachers[index].collect_metadata()
+            metadata = cachers[index].save_metadata()
+            artifact.metadata = metadata
 
             # TODO: (3/20/2023) with cacher refactoring, up to this point this is fine,
             # we would still call save on the cacher normally, and additionally
@@ -883,26 +907,27 @@ def _store_outputs(
 
             # check if we store an additional run output copy
             # TODO: (3/20/2023) can get rid of entirely if we manage via tracked paths
-            if record.manager.store_full:
-                cachers[index].set_path(
-                    record.manager.get_artifact_path(outputs[index], record, store=True)
-                )
-                logging.debug(f"Caching {outputs[index]} to '{cachers[index].path}'...")
-                cachers[index].save(output)
+            # if record.manager.store_full:
+            #     cachers[index].set_path(
+            #         record.manager.get_artifact_path(outputs[index], record, store=True)
+            #     )
+            #     logging.debug(f"Caching {outputs[index]} to '{cachers[index].path}'...")
+            #     cachers[index].save(output)
 
         # if specified as lazy, be sure to populate the cacher
         if type(outputs[index]) == Lazy:
             outputs[index].cacher = cachers[index]
 
     # store any additionally tracked paths as needed
-    if record.manager.store_full:
-        for obj_name, path in record.unstored_tracked_paths:
-            full_store_path = record.manager.get_artifact_path(
-                obj_name, record=record, store=True
-            )
-            logging.debug(f"Copying tracked path '{path}' to '{full_store_path}'...")
-            if os.path.isdir(path):
-                shutil.copytree(path, full_store_path)
-            else:
-                shutil.copy(path, full_store_path)
-    record.unstored_tracked_paths = []
+    # just call this from the decorator maybe?
+    # if record.manager.store_full:
+    #     for obj_name, path in record.unstored_tracked_paths:
+    #         full_store_path = record.manager.get_artifact_path(
+    #             obj_name, record=record, store=True
+    #         )
+    #         logging.debug(f"Copying tracked path '{path}' to '{full_store_path}'...")
+    #         if os.path.isdir(path):
+    #             shutil.copytree(path, full_store_path)
+    #         else:
+    #             shutil.copy(path, full_store_path)
+    # record.unstored_tracked_paths = []

--- a/curifactory/staging.py
+++ b/curifactory/staging.py
@@ -688,14 +688,14 @@ def _check_cached_outputs(stage_name, record, outputs, cachers, records=None):
         for index, arg in enumerate(outputs):
             if cachers[index].path_override is None:
                 # the str(arg) will handle Lazy objects
-                path = record.manager.get_path(str(arg), record)
+                path = record.manager.get_artifact_path(str(arg), record)
             elif str.endswith(cachers[index].extension, cachers[index].path_override):
                 # if the path override includes the extension they provided a full file name
                 # NOTE: this is useful if there's a static file that won't change across diff
                 # runs or paramsets, like an input dataset
                 path = cachers[index].path
             else:
-                path = record.manager.get_path(
+                path = record.manager.get_artifact_path(
                     arg,
                     record,
                     base_path=cachers[index].path,
@@ -732,7 +732,9 @@ def _check_cached_outputs(stage_name, record, outputs, cachers, records=None):
                     # eat the memory costs of reloading and resaving.)
                     previous_path = cachers[i].path
                     cachers[i].set_path(
-                        record.manager.get_path(outputs[i], record, output=True)
+                        record.manager.get_artifact_path(
+                            outputs[i], record, output=True
+                        )
                     )
                     if type(outputs[i]) == Lazy:
                         shutil.copyfile(previous_path, cachers[i].path)
@@ -770,7 +772,7 @@ def _check_cached_reportables(stage_name, record, aggregate_records=None):
     reportables_list_cacher = FileReferenceCacher()
     reportables_list_cacher.record = record
     reportables_list_cacher.set_path(
-        record.manager.get_path("reportables_file_list", record)
+        record.manager.get_artifact_path("reportables_file_list", record)
     )
     if reportables_list_cacher.check():
         paths = reportables_list_cacher.load()
@@ -817,7 +819,7 @@ def _store_reportables(stage_name, record, aggregate_records=None):
     reportables_list_cacher = FileReferenceCacher()
     reportables_list_cacher.record = record
     reportables_list_cacher.set_path(
-        record.manager.get_path("reportables_file_list", record)
+        record.manager.get_artifact_path("reportables_file_list", record)
     )
     reportables_list_cacher.save(paths)
     # NOTE: unnecessary because the reportables don't get copied over anyway, see todo note above.
@@ -884,7 +886,9 @@ def _store_outputs(
             # TODO: (3/20/2023) can get rid of entirely if we manage via tracked paths
             if record.manager.store_entire_run:
                 cachers[index].set_path(
-                    record.manager.get_path(outputs[index], record, output=True)
+                    record.manager.get_artifact_path(
+                        outputs[index], record, output=True
+                    )
                 )
                 logging.debug(f"Caching {outputs[index]} to '{cachers[index].path}'...")
                 cachers[index].save(output)
@@ -896,7 +900,7 @@ def _store_outputs(
     # store any additionally tracked paths as needed
     if record.manager.store_entire_run:
         for obj_name, path in record.additional_tracked_paths:
-            full_store_path = record.manager.get_path(
+            full_store_path = record.manager.get_artifact_path(
                 obj_name, record=record, output=True
             )
             logging.debug(f"Copying tracked path '{path}' to '{full_store_path}'...")

--- a/curifactory/staging.py
+++ b/curifactory/staging.py
@@ -896,7 +896,7 @@ def _store_outputs(
 
     # store any additionally tracked paths as needed
     if record.manager.store_entire_run:
-        for obj_name, path in record.additional_tracked_paths:
+        for obj_name, path in record.unstored_tracked_paths:
             full_store_path = record.manager.get_artifact_path(
                 obj_name, record=record, store=True
             )
@@ -905,4 +905,4 @@ def _store_outputs(
                 shutil.copytree(path, full_store_path)
             else:
                 shutil.copy(path, full_store_path)
-    record.additional_tracked_paths = []
+    record.unstored_tracked_paths = []

--- a/curifactory/staging.py
+++ b/curifactory/staging.py
@@ -850,9 +850,12 @@ def _store_reportables(stage_name, record, aggregate_records=None):
     # write a cache file out containing the reportables path names.
     reportables_list_cacher = FileReferenceCacher(
         name="reportables_file_list", record=record
-    ).save(paths)
+    )
+    reportables_list_cacher.save(paths)
 
     # send along metadata for it, to track when the reportables were generated.
+    # NOTE: we've already collected_metadata from passing record in init up above,
+    # so we don't need to use the extra_metadata field on the cacher.
     reportables_list_cacher.metadata["extra"]["reportables"] = True
     reportables_list_cacher.save_metadata()
     # NOTE: unnecessary because the reportables don't get copied over anyway, see todo note above.
@@ -906,7 +909,7 @@ def _store_outputs(
                 f"Caching {outputs[index]} to '{cachers[index].get_path()}'..."
             )
             cachers[index].save(output)
-            artifact.file = cachers[index].path
+            artifact.file = cachers[index].get_path()
 
             # generate and save metadata
             # note that if we got to this point, we actually ran the stage code, so

--- a/curifactory/staging.py
+++ b/curifactory/staging.py
@@ -274,6 +274,9 @@ def stage(  # noqa: C901 -- TODO: will be difficult to simplify...
                     # set the active record on the cacher as well as provide a default name
                     # (the name of the output)
                     cachers[i].set_record(record)
+                    cachers[
+                        i
+                    ].stage = name  # set current stage name, so get_path is correct in later stages (particularly for lazy)
                     if cachers[i].name is None and cachers[i].path_override is None:
                         if type(outputs[i]) == Lazy:
                             cachers[i].name = outputs[i].name
@@ -566,6 +569,9 @@ def aggregate(  # noqa: C901 -- TODO: will be difficult to simplify...
                     # set the active record on the cacher as well as provide a default name
                     # (the name of the output)
                     cachers[i].set_record(record)
+                    cachers[
+                        i
+                    ].stage = name  # set current stage name, so get_path is correct in later stages (particularly for lazy)
                     if cachers[i].name is None and cachers[i].path_override is None:
                         if type(outputs[i]) == Lazy:
                             cachers[i].name = outputs[i].name

--- a/curifactory/staging.py
+++ b/curifactory/staging.py
@@ -871,6 +871,15 @@ def _store_outputs(
             cachers[index].save(output)
             artifact.file = cachers[index].path
 
+            # TODO: (3/20/2023) with cacher refactoring, up to this point this is fine,
+            # we would still call save on the cacher normally, and additionally
+            # save a metadata file here (which we'd run the same record.get_path for,
+            # taking the exact same object names as were usedi n the cacher)
+            # NOTE: this means that the stage's get_path will need to also track
+            # what paths were added through it, since 1. we may not be tracking, and 2.
+            # by time it hits the record additional tracked paths, we lose info about
+            # where it came from.
+
             # check if we store an additional run output copy
             # TODO: (3/20/2023) can get rid of entirely if we manage via tracked paths
             if record.manager.store_entire_run:

--- a/curifactory/staging.py
+++ b/curifactory/staging.py
@@ -727,7 +727,7 @@ def _check_cached_outputs(stage_name, record, outputs, cachers, records=None):
                 artifact.file = cachers[i].path
 
                 # copy it over to output run folder if necessary
-                if record.manager.store_entire_run:
+                if record.manager.store_full:
                     # if we don't handle lazy separately it will literally store the lazy object.
                     # Instead, just use the OS to copy the file over. (This avoids us having to
                     # eat the memory costs of reloading and resaving.)
@@ -823,7 +823,7 @@ def _store_reportables(stage_name, record, aggregate_records=None):
     reportables_list_cacher.save(paths)
     # NOTE: unnecessary because the reportables don't get copied over anyway, see todo note above.
     # (we should get this for free without needing this code when we add extra path tracking to the manager.)
-    # if record.manager.store_entire_run:
+    # if record.manager.store_full:
     #     reportables_list_cacher.set_path(
     #         record.manager.get_path(
     #             "reportables_file_list",
@@ -883,7 +883,7 @@ def _store_outputs(
 
             # check if we store an additional run output copy
             # TODO: (3/20/2023) can get rid of entirely if we manage via tracked paths
-            if record.manager.store_entire_run:
+            if record.manager.store_full:
                 cachers[index].set_path(
                     record.manager.get_artifact_path(outputs[index], record, store=True)
                 )
@@ -895,7 +895,7 @@ def _store_outputs(
             outputs[index].cacher = cachers[index]
 
     # store any additionally tracked paths as needed
-    if record.manager.store_entire_run:
+    if record.manager.store_full:
         for obj_name, path in record.unstored_tracked_paths:
             full_store_path = record.manager.get_artifact_path(
                 obj_name, record=record, store=True

--- a/curifactory/store.py
+++ b/curifactory/store.py
@@ -117,7 +117,7 @@ class ManagerStore:
             "workdir_dirty": mngr.git_workdir_dirty,
             "params_files": mngr.experiment_args_file_list,
             "args": mngr.experiment_args,
-            "full_store": mngr.store_entire_run,
+            "full_store": mngr.store_full,
             "status": "incomplete",
             "cli": mngr.run_line,
             "hostname": mngr.hostname,
@@ -125,7 +125,7 @@ class ManagerStore:
         }
 
         # sanitize reproduction cli command
-        if mngr.store_entire_run:
+        if mngr.store_full:
             run = self._get_reproduction_line(mngr, run)
 
         self.runs.append(run)
@@ -144,9 +144,9 @@ class ManagerStore:
         if sanitized_run_line.endswith("--store-full"):
             sanitized_run_line = sanitized_run_line[:-13]
 
-        store_entire_run_path = os.path.join(mngr.runs_path, mngr.get_reference_name())
+        cache_path = mngr.get_run_output_path()
         mngr.reproduction_line = (
-            f"{sanitized_run_line} --cache {store_entire_run_path} --dry-cache"
+            f"{sanitized_run_line} --cache {cache_path} --dry-cache"
         )
 
         run["reproduce"] = mngr.reproduction_line
@@ -178,7 +178,7 @@ class ManagerStore:
         run_info["params_files"] = mngr.experiment_args_file_list
         run_info["args"] = mngr.experiment_args
 
-        if mngr.store_entire_run:
+        if mngr.store_full:
             run_info = self._get_reproduction_line(mngr, run_info)
 
         self.runs[index] = run_info

--- a/curifactory/store.py
+++ b/curifactory/store.py
@@ -146,7 +146,7 @@ class ManagerStore:
 
         cache_path = mngr.get_run_output_path()
         mngr.reproduction_line = (
-            f"{sanitized_run_line} --cache {cache_path} --dry-cache"
+            f"{sanitized_run_line} --cache {cache_path}/artifacts --dry-cache"
         )
 
         run["reproduce"] = mngr.reproduction_line

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -81,6 +81,18 @@ def configured_test_manager(
     shutil.rmtree("test/examples/data", ignore_errors=True)
 
 
+@pytest.fixture()
+def alternate_test_manager2(
+    mocker, configuration  # noqa: F811 -- mocker has to be passed in as fixture
+):
+    """Meant for tests where a second artifact manager with a different 'experiment'
+    is needed."""
+    mock = mocker.patch("curifactory.utils.get_configuration")
+    mock.return_value = configuration
+
+    return ArtifactManager("test2", live_log_debug=True)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def clear_proj_root():
     yield

--- a/test/test_caching.py
+++ b/test/test_caching.py
@@ -651,3 +651,39 @@ def test_pandas_json_cacher_with_df_no_recursion_error(configured_test_manager):
     assert os.path.exists(path)
     df = pd.read_json(path)
     np.testing.assert_almost_equal(df.values, data)
+
+
+"""A basic cacher output should also output a metadata file associated with it."""
+
+"""A cacher output should copy the associated metadata file to the full store if full store mode."""
+
+"""A non-tracked cacher should not copy the metadata file to the full store."""
+
+"""A full store output that's using a cached value should transfer the _existing_ metadata file
+to the full store."""
+
+
+"""A cacher with path-override set should save the output to that path."""
+
+"""A manual cacher with path-override set should save and load the output to that path."""
+
+"""A manual cacher with record.get_path static path should correctly save and load to that path."""
+
+"""A manual cacher with record.get_path static path should correctly store to that path in
+full store in full store mode."""
+
+"""QSTN: what happens when path-override set in cacher and store full?"""
+
+"""QSTN: what happens when path-override set in manual cacher and store full?"""
+
+
+"""Two separate managers with different paths but a common stage with custom prefix should
+both use the same cached value if the args are the same."""
+
+"""Two separate managers with different paths but a common stage with custom prefix should
+_not_ use the same cached value if the args are not the same."""
+
+
+"""A manual cacher used with a static path should be transferred to the full store. (I think?)"""
+
+"""A cacher used with a static path should be transferred to the full store. (I think?)"""

--- a/test/test_caching.py
+++ b/test/test_caching.py
@@ -375,7 +375,7 @@ def test_aggregate_no_args_records_overwrite_doesnot_load_cache(
 def test_get_path_file_included_in_full_store(configured_test_manager):
     """A file manually saved within a stage using get_path should correctly be
     copied to the run folder in a full-store run."""
-    configured_test_manager.store_entire_run = True
+    configured_test_manager.store_full = True
 
     @cf.stage(None, ["other_output"], [PickleCacher])
     def custom_output(record):
@@ -404,7 +404,7 @@ def test_get_path_file_included_in_full_store(configured_test_manager):
 def test_get_dir_folder_included_in_full_store(configured_test_manager):
     """File(s) manually saved within a stage using get_dir should correctly be
     copied to the run folder in a full-store run."""
-    configured_test_manager.store_entire_run = True
+    configured_test_manager.store_full = True
 
     @cf.stage(None, ["other_output"], [PickleCacher])
     def custom_output(record):
@@ -434,7 +434,7 @@ def test_get_dir_folder_included_in_full_store(configured_test_manager):
 def test_get_path_file_excluded_in_full_store_when_not_tracked(configured_test_manager):
     """A file manually saved within a stage using get_path should NOT be
     copied to the run folder in a full-store run when not tracked."""
-    configured_test_manager.store_entire_run = True
+    configured_test_manager.store_full = True
 
     @cf.stage(None, ["other_output"], [PickleCacher])
     def custom_output(record):
@@ -465,7 +465,7 @@ def test_get_dir_folder_excluded_in_full_store_when_not_tracked(
 ):
     """File(s) manually saved within a stage using get_dir should NOT be
     copied to the run folder in a full-store run when not tracked."""
-    configured_test_manager.store_entire_run = True
+    configured_test_manager.store_full = True
 
     @cf.stage(None, ["other_output"], [PickleCacher])
     def custom_output(record):

--- a/test/test_caching.py
+++ b/test/test_caching.py
@@ -1,10 +1,13 @@
 import json
 import os
+from test.examples.stages.cache_stages import (
+    filerefcacher_stage,
+    filerefcacher_stage_multifile,
+)
 
 import numpy as np
 import pandas as pd
 import pytest
-from stages.cache_stages import filerefcacher_stage, filerefcacher_stage_multifile
 
 import curifactory as cf
 from curifactory.caching import PandasCsvCacher, PandasJsonCacher, PickleCacher
@@ -385,7 +388,7 @@ def test_get_path_file_included_in_full_store(configured_test_manager):
     r0 = cf.Record(configured_test_manager, cf.ExperimentArgs(name="test"))
     custom_output(r0)
 
-    full_store_path = f"{configured_test_manager.runs_path}/test_1_{configured_test_manager.get_str_timestamp()}"
+    full_store_path = f"{configured_test_manager.runs_path}/test_1_{configured_test_manager.get_str_timestamp()}/artifacts"
 
     regular_custom_output_path = os.path.join(
         configured_test_manager.cache_path,
@@ -414,7 +417,7 @@ def test_get_dir_folder_included_in_full_store(configured_test_manager):
     r0 = cf.Record(configured_test_manager, cf.ExperimentArgs(name="test"))
     custom_output(r0)
 
-    full_store_path = f"{configured_test_manager.runs_path}/test_1_{configured_test_manager.get_str_timestamp()}"
+    full_store_path = f"{configured_test_manager.runs_path}/test_1_{configured_test_manager.get_str_timestamp()}/artifacts"
 
     regular_custom_output_path = os.path.join(
         configured_test_manager.cache_path,
@@ -435,7 +438,7 @@ def test_get_path_file_excluded_in_full_store_when_not_tracked(configured_test_m
 
     @cf.stage(None, ["other_output"], [PickleCacher])
     def custom_output(record):
-        path = record.get_path("my_extra_file.txt", False)
+        path = record.get_path("my_extra_file.txt", track=False)
         with open(path, "w") as outfile:
             outfile.write("Hello world!")
 
@@ -444,7 +447,7 @@ def test_get_path_file_excluded_in_full_store_when_not_tracked(configured_test_m
     r0 = cf.Record(configured_test_manager, cf.ExperimentArgs(name="test"))
     custom_output(r0)
 
-    full_store_path = f"{configured_test_manager.runs_path}/test_1_{configured_test_manager.get_str_timestamp()}"
+    full_store_path = f"{configured_test_manager.runs_path}/test_1_{configured_test_manager.get_str_timestamp()}/artifacts"
 
     regular_custom_output_path = os.path.join(
         configured_test_manager.cache_path,
@@ -466,7 +469,7 @@ def test_get_dir_folder_excluded_in_full_store_when_not_tracked(
 
     @cf.stage(None, ["other_output"], [PickleCacher])
     def custom_output(record):
-        path = record.get_dir("my_extra_dir", False)
+        path = record.get_dir("my_extra_dir", track=False)
         with open(f"{path}/testfile.txt", "w") as outfile:
             outfile.write("Hello world!")
 
@@ -475,7 +478,7 @@ def test_get_dir_folder_excluded_in_full_store_when_not_tracked(
     r0 = cf.Record(configured_test_manager, cf.ExperimentArgs(name="test"))
     custom_output(r0)
 
-    full_store_path = f"{configured_test_manager.runs_path}/test_1_{configured_test_manager.get_str_timestamp()}"
+    full_store_path = f"{configured_test_manager.runs_path}/test_1_{configured_test_manager.get_str_timestamp()}/artifacts"
 
     regular_custom_output_path = os.path.join(
         configured_test_manager.cache_path,

--- a/test/test_caching.py
+++ b/test/test_caching.py
@@ -1079,11 +1079,3 @@ def test_cacher_with_record_get_path_no_extension_full_store(configured_test_man
         f"test_{r0.args.hash}_manual_output_thing_manualtest",
     )
     assert os.path.exists(path)
-
-
-"""A manual cacher used with a static path should be transferred to the full store. (I think?)"""
-
-"""A cacher used with a static path should be transferred to the full store. (I think?)"""
-
-
-# TODO: expected functionality when record is not set/no info is set, etc.?

--- a/test/test_experiment.py
+++ b/test/test_experiment.py
@@ -17,7 +17,7 @@ from curifactory.manager import ArtifactManager
         (
             dict(experiment_name="test", parameters_list=["params1", "params2"]),
             dict(
-                store_entire_run=False,
+                store_full=False,
                 dry=False,
                 dry_cache=False,
                 custom_name=None,
@@ -31,7 +31,7 @@ from curifactory.manager import ArtifactManager
         (
             dict(experiment_name="test", parameters_list=[]),
             dict(
-                store_entire_run=False,
+                store_full=False,
                 dry=False,
                 dry_cache=False,
                 custom_name=None,
@@ -49,7 +49,7 @@ from curifactory.manager import ArtifactManager
                 cache_dir_override="test/examples/data/superspecialcache",
             ),
             dict(
-                store_entire_run=False,
+                store_full=False,
                 dry=False,
                 dry_cache=False,
                 custom_name=None,
@@ -64,10 +64,10 @@ from curifactory.manager import ArtifactManager
             dict(
                 experiment_name="test",
                 parameters_list=["params1"],
-                store_entire_run=True,
+                store_full=True,
             ),
             dict(
-                store_entire_run=True,
+                store_full=True,
                 dry=False,
                 dry_cache=False,
                 custom_name=None,
@@ -86,7 +86,7 @@ from curifactory.manager import ArtifactManager
                 dry_cache=True,
             ),
             dict(
-                store_entire_run=False,
+                store_full=False,
                 dry=True,
                 dry_cache=True,
                 custom_name=None,
@@ -104,7 +104,7 @@ from curifactory.manager import ArtifactManager
                 custom_name="custom_test",
             ),
             dict(
-                store_entire_run=False,
+                store_full=False,
                 dry=False,
                 dry_cache=False,
                 custom_name="custom_test",
@@ -118,7 +118,7 @@ from curifactory.manager import ArtifactManager
         (
             dict(experiment_name="test", parameters_list=["params1"], lazy=True),
             dict(
-                store_entire_run=False,
+                store_full=False,
                 dry=False,
                 dry_cache=False,
                 custom_name=None,
@@ -132,7 +132,7 @@ from curifactory.manager import ArtifactManager
         (
             dict(experiment_name="test", parameters_list=["params1"], ignore_lazy=True),
             dict(
-                store_entire_run=False,
+                store_full=False,
                 dry=False,
                 dry_cache=False,
                 custom_name=None,
@@ -201,7 +201,7 @@ def test_rank_manager_integration(
         pass
     mock.assert_called_once_with(
         "test",
-        store_entire_run=False,
+        store_full=False,
         dry=False,
         dry_cache=False,
         custom_name=None,
@@ -235,7 +235,7 @@ def test_rank_manager_store_full_integration(
     clear_rank_env_vars,
 ):
     """A rank-zero process in a distributed run with store full should still set
-    'store_entire_run' on manager."""
+    'store_full' on manager."""
     if local_rank is not None:
         os.environ["LOCAL_RANK"] = str(local_rank)
     if node_rank is not None:
@@ -244,7 +244,7 @@ def test_rank_manager_store_full_integration(
     mock = mocker.patch.object(ArtifactManager, "__init__", return_value=None)
     try:
         run_experiment(
-            experiment_name="test", parameters_list=["params1"], store_entire_run=True
+            experiment_name="test", parameters_list=["params1"], store_full=True
         )
     except AttributeError:
         # NOTE: I'm not actually sure a better way around this, all I want to test is that
@@ -252,7 +252,7 @@ def test_rank_manager_store_full_integration(
         pass
     mock.assert_called_once_with(
         "test",
-        store_entire_run=expect_store_full,
+        store_full=expect_store_full,
         dry=False,
         dry_cache=False,
         custom_name=None,

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -2,6 +2,7 @@
 
 import os
 
+import pytest
 from pytest_mock import mocker  # noqa: F401 -- flake8 doesn't see it's used as fixture
 
 from curifactory import ExperimentArgs, Record, aggregate, hashing, stage
@@ -43,6 +44,9 @@ def test_stage_integration_basic(
     mock.assert_called_once_with("test_output", record)
 
 
+# TODO: path_override is going to work a little differently, but this general test might
+# end up belonging in the test_caching, so keep around for now
+@pytest.mark.skip
 def test_stage_integration_path_override(
     mocker,  # noqa: F811 -- mocker has to be passed in as fixture
     sample_args,
@@ -84,7 +88,7 @@ def test_stage_integration_storefull(
     assert mock.call_args_list[0].args == ("test_output", record)
     assert mock.call_args_list[0].kwargs == dict()
     assert mock.call_args_list[1].args == ("test_output", record)
-    assert mock.call_args_list[1].kwargs == dict(output=True)
+    assert mock.call_args_list[1].kwargs == dict(store=True)
 
 
 # -----------------------------------------
@@ -107,6 +111,8 @@ def test_get_path_basic_w_stagename(sample_args, configured_test_manager):
     assert path == "test/examples/data/cache/test_sample_hash_somestage_test_output"
 
 
+# TODO: see above
+@pytest.mark.skip
 def test_get_path_path_override(sample_args, configured_test_manager):
     """Calling get_artifact_path with a basic set of args and a path override should return the expected path."""
     record = Record(configured_test_manager, sample_args)
@@ -121,10 +127,10 @@ def test_get_path_store_full(sample_args, configured_test_manager):
     record = Record(configured_test_manager, sample_args)
     configured_test_manager.store_entire_run = True
     ts = configured_test_manager.get_str_timestamp()
-    path = configured_test_manager.get_artifact_path("test_output", record, output=True)
+    path = configured_test_manager.get_artifact_path("test_output", record, store=True)
     assert (
         path
-        == f"test/examples/data/runs/test_{configured_test_manager.experiment_run_number}_{ts}/test_sample_hash__test_output"
+        == f"test/examples/data/runs/test_{configured_test_manager.experiment_run_number}_{ts}/artifacts/test_sample_hash__test_output"
     )
 
 
@@ -142,10 +148,10 @@ def test_get_path_custom_name_and_store_full(sample_args, configured_test_manage
     configured_test_manager.store_entire_run = True
     configured_test_manager.custom_name = "some_custom_name"
     ts = configured_test_manager.get_str_timestamp()
-    path = configured_test_manager.get_artifact_path("test_output", record, output=True)
+    path = configured_test_manager.get_artifact_path("test_output", record, store=True)
     assert (
         path
-        == f"test/examples/data/runs/test_{configured_test_manager.experiment_run_number}_{ts}/some_custom_name_sample_hash__test_output"
+        == f"test/examples/data/runs/test_{configured_test_manager.experiment_run_number}_{ts}/artifacts/some_custom_name_sample_hash__test_output"
     )
 
 

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -20,7 +20,7 @@ class FakeCacher(Cacheable):
 
 
 # -----------------------------------------
-# Stage/manager.get_path intergration tests
+# Stage/manager.get_artifact_path intergration tests
 # -----------------------------------------
 
 
@@ -29,9 +29,9 @@ def test_stage_integration_basic(
     sample_args,
     configured_test_manager,
 ):
-    """The stage should be calling manager's get_path with the correct parameters."""
+    """The stage should be calling manager's get_artifact_path with the correct parameters."""
     mock = mocker.patch.object(
-        configured_test_manager, "get_path", return_value="test_path"
+        configured_test_manager, "get_artifact_path", return_value="test_path"
     )
 
     @stage([], ["test_output"], [FakeCacher])
@@ -48,9 +48,9 @@ def test_stage_integration_path_override(
     sample_args,
     configured_test_manager,
 ):
-    """The stage should be calling manager's get_path with the correct parameters when using a path override in a cacher."""
+    """The stage should be calling manager's get_artifact_path with the correct parameters when using a path override in a cacher."""
     mock = mocker.patch.object(
-        configured_test_manager, "get_path", return_value="test_path"
+        configured_test_manager, "get_artifact_path", return_value="test_path"
     )
 
     @stage([], ["test_output"], [FakeCacher(path_override="test/examples/WHAT")])
@@ -67,10 +67,10 @@ def test_stage_integration_storefull(
     sample_args,
     configured_test_manager,
 ):
-    """The stage should be calling manager's get_path twice with the correct parameters."""
+    """The stage should be calling manager's get_artifact_path twice with the correct parameters."""
     configured_test_manager.store_entire_run = True
     mock = mocker.patch.object(
-        configured_test_manager, "get_path", return_value="test_path"
+        configured_test_manager, "get_artifact_path", return_value="test_path"
     )
 
     @stage([], ["test_output"], [FakeCacher])
@@ -88,40 +88,40 @@ def test_stage_integration_storefull(
 
 
 # -----------------------------------------
-# get_path unit tests
+# get_artifact_path unit tests
 # -----------------------------------------
 
 
 def test_get_path_basic(sample_args, configured_test_manager):
-    """Calling get_path with a basic set of args should return the expected path."""
+    """Calling get_artifact_path with a basic set of args should return the expected path."""
     record = Record(configured_test_manager, sample_args)
-    path = configured_test_manager.get_path("test_output", record)
+    path = configured_test_manager.get_artifact_path("test_output", record)
     assert path == "test/examples/data/cache/test_sample_hash__test_output"
 
 
 def test_get_path_basic_w_stagename(sample_args, configured_test_manager):
-    """Calling get_path with a basic set of args and a valid stage name should return the expected path."""
+    """Calling get_artifact_path with a basic set of args and a valid stage name should return the expected path."""
     record = Record(configured_test_manager, sample_args)
     configured_test_manager.current_stage_name = "somestage"
-    path = configured_test_manager.get_path("test_output", record)
+    path = configured_test_manager.get_artifact_path("test_output", record)
     assert path == "test/examples/data/cache/test_sample_hash_somestage_test_output"
 
 
 def test_get_path_path_override(sample_args, configured_test_manager):
-    """Calling get_path with a basic set of args and a path override should return the expected path."""
+    """Calling get_artifact_path with a basic set of args and a path override should return the expected path."""
     record = Record(configured_test_manager, sample_args)
-    path = configured_test_manager.get_path(
+    path = configured_test_manager.get_artifact_path(
         "test_output", record, base_path="test/examples/WHAT"
     )
     assert path == "test/examples/WHAT/test_sample_hash__test_output"
 
 
 def test_get_path_store_full(sample_args, configured_test_manager):
-    """Calling get_path with store-full should return the expected path."""
+    """Calling get_artifact_path with store-full should return the expected path."""
     record = Record(configured_test_manager, sample_args)
     configured_test_manager.store_entire_run = True
     ts = configured_test_manager.get_str_timestamp()
-    path = configured_test_manager.get_path("test_output", record, output=True)
+    path = configured_test_manager.get_artifact_path("test_output", record, output=True)
     assert (
         path
         == f"test/examples/data/runs/test_{configured_test_manager.experiment_run_number}_{ts}/test_sample_hash__test_output"
@@ -129,20 +129,20 @@ def test_get_path_store_full(sample_args, configured_test_manager):
 
 
 def test_get_path_custom_name(sample_args, configured_test_manager):
-    """Calling get_path when a custom name is in use should return the expected path."""
+    """Calling get_artifact_path when a custom name is in use should return the expected path."""
     record = Record(configured_test_manager, sample_args)
     configured_test_manager.custom_name = "some_custom_name"
-    path = configured_test_manager.get_path("test_output", record)
+    path = configured_test_manager.get_artifact_path("test_output", record)
     assert path == "test/examples/data/cache/some_custom_name_sample_hash__test_output"
 
 
 def test_get_path_custom_name_and_store_full(sample_args, configured_test_manager):
-    """Calling get_path when a custom name is in use and storefull is called should return the expected path."""
+    """Calling get_artifact_path when a custom name is in use and storefull is called should return the expected path."""
     record = Record(configured_test_manager, sample_args)
     configured_test_manager.store_entire_run = True
     configured_test_manager.custom_name = "some_custom_name"
     ts = configured_test_manager.get_str_timestamp()
-    path = configured_test_manager.get_path("test_output", record, output=True)
+    path = configured_test_manager.get_artifact_path("test_output", record, output=True)
     assert (
         path
         == f"test/examples/data/runs/test_{configured_test_manager.experiment_run_number}_{ts}/some_custom_name_sample_hash__test_output"
@@ -150,9 +150,9 @@ def test_get_path_custom_name_and_store_full(sample_args, configured_test_manage
 
 
 def test_get_path_no_args(configured_test_manager):
-    """Calling get_path with None args will result in None in the output name."""
+    """Calling get_artifact_path with None args will result in None in the output name."""
     record = Record(configured_test_manager, None)
-    path = configured_test_manager.get_path("test_output", record)
+    path = configured_test_manager.get_artifact_path("test_output", record)
     assert path == f"test/examples/data/cache/test_{record.combo_hash}__test_output"
 
 

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -40,7 +40,7 @@ def test_stage_integration_basic(
 
     record = Record(configured_test_manager, sample_args)
     do_thing(record)
-    mock.assert_called_once_with("test_output", record, aggregate_records=None)
+    mock.assert_called_once_with("test_output", record)
 
 
 def test_stage_integration_path_override(
@@ -59,9 +59,7 @@ def test_stage_integration_path_override(
 
     record = Record(configured_test_manager, sample_args)
     do_thing(record)
-    mock.assert_called_once_with(
-        "test_output", record, base_path="test/examples/WHAT", aggregate_records=None
-    )
+    mock.assert_called_once_with("test_output", record, base_path="test/examples/WHAT")
 
 
 def test_stage_integration_storefull(
@@ -84,9 +82,9 @@ def test_stage_integration_storefull(
 
     assert len(mock.call_args_list) == 2
     assert mock.call_args_list[0].args == ("test_output", record)
-    assert mock.call_args_list[0].kwargs == dict(aggregate_records=None)
+    assert mock.call_args_list[0].kwargs == dict()
     assert mock.call_args_list[1].args == ("test_output", record)
-    assert mock.call_args_list[1].kwargs == dict(output=True, aggregate_records=None)
+    assert mock.call_args_list[1].kwargs == dict(output=True)
 
 
 # -----------------------------------------
@@ -97,9 +95,7 @@ def test_stage_integration_storefull(
 def test_get_path_basic(sample_args, configured_test_manager):
     """Calling get_path with a basic set of args should return the expected path."""
     record = Record(configured_test_manager, sample_args)
-    path = configured_test_manager.get_path(
-        "test_output", record, aggregate_records=None
-    )
+    path = configured_test_manager.get_path("test_output", record)
     assert path == "test/examples/data/cache/test_sample_hash__test_output"
 
 
@@ -107,9 +103,7 @@ def test_get_path_basic_w_stagename(sample_args, configured_test_manager):
     """Calling get_path with a basic set of args and a valid stage name should return the expected path."""
     record = Record(configured_test_manager, sample_args)
     configured_test_manager.current_stage_name = "somestage"
-    path = configured_test_manager.get_path(
-        "test_output", record, aggregate_records=None
-    )
+    path = configured_test_manager.get_path("test_output", record)
     assert path == "test/examples/data/cache/test_sample_hash_somestage_test_output"
 
 
@@ -117,7 +111,7 @@ def test_get_path_path_override(sample_args, configured_test_manager):
     """Calling get_path with a basic set of args and a path override should return the expected path."""
     record = Record(configured_test_manager, sample_args)
     path = configured_test_manager.get_path(
-        "test_output", record, base_path="test/examples/WHAT", aggregate_records=None
+        "test_output", record, base_path="test/examples/WHAT"
     )
     assert path == "test/examples/WHAT/test_sample_hash__test_output"
 
@@ -127,9 +121,7 @@ def test_get_path_store_full(sample_args, configured_test_manager):
     record = Record(configured_test_manager, sample_args)
     configured_test_manager.store_entire_run = True
     ts = configured_test_manager.get_str_timestamp()
-    path = configured_test_manager.get_path(
-        "test_output", record, output=True, aggregate_records=None
-    )
+    path = configured_test_manager.get_path("test_output", record, output=True)
     assert (
         path
         == f"test/examples/data/runs/test_{configured_test_manager.experiment_run_number}_{ts}/test_sample_hash__test_output"
@@ -140,9 +132,7 @@ def test_get_path_custom_name(sample_args, configured_test_manager):
     """Calling get_path when a custom name is in use should return the expected path."""
     record = Record(configured_test_manager, sample_args)
     configured_test_manager.custom_name = "some_custom_name"
-    path = configured_test_manager.get_path(
-        "test_output", record, aggregate_records=None
-    )
+    path = configured_test_manager.get_path("test_output", record)
     assert path == "test/examples/data/cache/some_custom_name_sample_hash__test_output"
 
 
@@ -152,9 +142,7 @@ def test_get_path_custom_name_and_store_full(sample_args, configured_test_manage
     configured_test_manager.store_entire_run = True
     configured_test_manager.custom_name = "some_custom_name"
     ts = configured_test_manager.get_str_timestamp()
-    path = configured_test_manager.get_path(
-        "test_output", record, output=True, aggregate_records=None
-    )
+    path = configured_test_manager.get_path("test_output", record, output=True)
     assert (
         path
         == f"test/examples/data/runs/test_{configured_test_manager.experiment_run_number}_{ts}/some_custom_name_sample_hash__test_output"
@@ -164,9 +152,7 @@ def test_get_path_custom_name_and_store_full(sample_args, configured_test_manage
 def test_get_path_no_args(configured_test_manager):
     """Calling get_path with None args will result in None in the output name."""
     record = Record(configured_test_manager, None)
-    path = configured_test_manager.get_path(
-        "test_output", record, aggregate_records=None
-    )
+    path = configured_test_manager.get_path("test_output", record)
     assert path == f"test/examples/data/cache/test_{record.combo_hash}__test_output"
 
 
@@ -303,6 +289,7 @@ def test_cache_aware_dict_no_resolve(configured_test_manager):
 # -----------------------------------------
 # hash-setting tests
 # -----------------------------------------
+
 
 # TODO: (05/09/2022) with and without an agg of None args
 def test_aggregate_stage_record_uses_combo_hash(configured_test_manager):

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -2,11 +2,10 @@
 
 import os
 
-import pytest
 from pytest_mock import mocker  # noqa: F401 -- flake8 doesn't see it's used as fixture
 
 from curifactory import ExperimentArgs, Record, aggregate, hashing, stage
-from curifactory.caching import Cacheable, JsonCacher, Lazy, PickleCacher
+from curifactory.caching import JsonCacher, Lazy, PickleCacher
 
 # -----------------------------------------
 # get_artifact_path unit tests
@@ -169,7 +168,7 @@ def test_run_line_sanitization_normal(configured_test_manager):
     ts = configured_test_manager.get_str_timestamp()
     assert (
         configured_test_manager.run_info["reproduce"]
-        == f"experiment test -p params1 --cache test/examples/data/runs/test_{configured_test_manager.experiment_run_number}_{ts} --dry-cache"
+        == f"experiment test -p params1 --cache test/examples/data/runs/test_{configured_test_manager.experiment_run_number}_{ts}/artifacts --dry-cache"
     )
 
 
@@ -183,7 +182,7 @@ def test_run_line_sanitization_order(configured_test_manager):
     ts = configured_test_manager.get_str_timestamp()
     assert (
         configured_test_manager.run_info["reproduce"]
-        == f"experiment test -p params1 --parallel 4 --cache test/examples/data/runs/test_{configured_test_manager.experiment_run_number}_{ts} --dry-cache"
+        == f"experiment test -p params1 --parallel 4 --cache test/examples/data/runs/test_{configured_test_manager.experiment_run_number}_{ts}/artifacts --dry-cache"
     )
 
 
@@ -197,7 +196,7 @@ def test_run_line_sanitization_overwrite(configured_test_manager):
     ts = configured_test_manager.get_str_timestamp()
     assert (
         configured_test_manager.run_info["reproduce"]
-        == f"experiment test -p params1 --parallel 4 --cache test/examples/data/runs/test_{configured_test_manager.experiment_run_number}_{ts} --dry-cache"
+        == f"experiment test -p params1 --parallel 4 --cache test/examples/data/runs/test_{configured_test_manager.experiment_run_number}_{ts}/artifacts --dry-cache"
     )
 
 

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -27,6 +27,19 @@ def test_get_path_basic_w_stagename(sample_args, configured_test_manager):
     assert path == "test/examples/data/cache/test_sample_hash_somestage_test_output"
 
 
+def test_get_path_basic_w_custom_stagename(sample_args, configured_test_manager):
+    """Calling get_artifact_path with a specific stage name should override the current stage name in the
+    returned path."""
+    record = Record(configured_test_manager, sample_args)
+    configured_test_manager.current_stage_name = "somestage"
+    path = configured_test_manager.get_artifact_path(
+        "test_output", record, stage_name="someotherstage"
+    )
+    assert (
+        path == "test/examples/data/cache/test_sample_hash_someotherstage_test_output"
+    )
+
+
 def test_get_path_subdir(sample_args, configured_test_manager):
     """Calling get_artifact_path with a basic set of args and a subdir should return the expected path."""
     record = Record(configured_test_manager, sample_args)

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -72,7 +72,7 @@ def test_stage_integration_storefull(
     configured_test_manager,
 ):
     """The stage should be calling manager's get_artifact_path twice with the correct parameters."""
-    configured_test_manager.store_entire_run = True
+    configured_test_manager.store_full = True
     mock = mocker.patch.object(
         configured_test_manager, "get_artifact_path", return_value="test_path"
     )
@@ -125,7 +125,7 @@ def test_get_path_path_override(sample_args, configured_test_manager):
 def test_get_path_store_full(sample_args, configured_test_manager):
     """Calling get_artifact_path with store-full should return the expected path."""
     record = Record(configured_test_manager, sample_args)
-    configured_test_manager.store_entire_run = True
+    configured_test_manager.store_full = True
     ts = configured_test_manager.get_str_timestamp()
     path = configured_test_manager.get_artifact_path("test_output", record, store=True)
     assert (
@@ -145,7 +145,7 @@ def test_get_path_custom_name(sample_args, configured_test_manager):
 def test_get_path_custom_name_and_store_full(sample_args, configured_test_manager):
     """Calling get_artifact_path when a custom name is in use and storefull is called should return the expected path."""
     record = Record(configured_test_manager, sample_args)
-    configured_test_manager.store_entire_run = True
+    configured_test_manager.store_full = True
     configured_test_manager.custom_name = "some_custom_name"
     ts = configured_test_manager.get_str_timestamp()
     path = configured_test_manager.get_artifact_path("test_output", record, store=True)
@@ -228,7 +228,7 @@ def test_write_run_env_output(configured_test_manager):
 def test_run_line_sanitization_normal(configured_test_manager):
     """Ensure that a normal store-full run-line will result in a correct reproduction line in the run info."""
     configured_test_manager.run_line = "experiment test -p params1 --store-full"
-    configured_test_manager.store_entire_run = True
+    configured_test_manager.store_full = True
     configured_test_manager.store()
     ts = configured_test_manager.get_str_timestamp()
     assert (
@@ -242,7 +242,7 @@ def test_run_line_sanitization_order(configured_test_manager):
     configured_test_manager.run_line = (
         "experiment test -p params1 --store-full --parallel 4"
     )
-    configured_test_manager.store_entire_run = True
+    configured_test_manager.store_full = True
     configured_test_manager.store()
     ts = configured_test_manager.get_str_timestamp()
     assert (
@@ -256,7 +256,7 @@ def test_run_line_sanitization_overwrite(configured_test_manager):
     configured_test_manager.run_line = (
         "experiment test -p params1 --store-full --parallel 4 --overwrite"
     )
-    configured_test_manager.store_entire_run = True
+    configured_test_manager.store_full = True
     configured_test_manager.store()
     ts = configured_test_manager.get_str_timestamp()
     assert (


### PR DESCRIPTION
I still need to write several tests for the new functionality, and a few other minor updates, but I wanted to get the PR going so people could start looking at the refactor and make sure we're on the same page about the conceptual changes.

To summarize:
* Metadata files are now stored along with every output path including experiment, run, record, and parameter information. This is intended to improve artifact provenance, as full store runs that use previously cached values will include the metadata about those previous values.
* Record/manager `get_path` computation has been expanded, and cachers now use that instead of expecting the stage to directly set the path on them, with the following benefits:
    * More consistent with how a user would manually cache/add paths to be tracked, so now all of the artifact files (metadata, reportables, cached outputs) use the same mechanism to transfer to the full store.
    * Cachers can be excluded from the full store folder by setting `track=False`
    * More control over subpath of an output within the cache/run directory, you can provide a subdirectory (allowing kedro data engineering convention like folder structure), and/or a prefix (instead of `[cache_dir]/[experiment_name]_[hash]_...` you can do `[cache_dir]/[custom_prefix]_[hash]_...`. This allows cross-experiment caching) 
* `save` doesn't get called on the cacher a second time to put it in the store full folder, instead the output files are just copied at the end of the stage. (Previously ran into some weird issues where a custom cacher was in an incomplete state because it had loaded something from cache (without the stage executing) and couldn't save a second time - but just copying the file would have worked)
* Store full runs store cached outputs into the run's `artifacts/` subdirectory (keeps that experiment run folder's root much cleaner)

Benefits:
* Much more control over individual cachers
* Path mechanisms are more consistent - will allow work on the non-auto-resolving lazy instances to progress (previously a blocker because of inconsistent cacher `path` state)
* Metadata = better provenance
* Fixes previously messy file extension handling (would fix #9)
* Very large data cached objects can work across experiments without duplicating on disk, and can be kept out of full store folders

Negatives:
* Breaking changes, any custom cachers need to update to use `self.get_path()` instead of `self.path`
* Custom cachers need to be more conscientious about the paths they're actually writing to - if writing out multiple paths per single cacher, will need to get each path with `self.get_path(some_suffix)` calls rather than getting the path once and modifying it, to avoid untracked files (unless it's a directory in which case the entire directory is tracked)