### PR TITLE
Create log directory if missing in init_logging

### DIFF
--- a/curifactory/utils.py
+++ b/curifactory/utils.py
@@ -416,6 +416,9 @@ def init_logging(
     set_logging_prefix("")
 
     if log_path is not None:
+        log_dir = os.path.dirname(log_path)
+        if log_dir and not os.path.exists(log_dir):
+            os.makedirs(log_dir, exist_ok=True)
         file_handler = logging.FileHandler(log_path)
         file_handler.setFormatter(plain_log_formatter)
         root_logger.addHandler(file_handler)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,22 @@
+import logging
+import os
+
 from curifactory import utils
+
+
+def test_init_logging_creates_missing_log_dir(tmp_path):
+    """init_logging should create the log file's parent directory when it
+    doesn't exist yet, rather than raising FileNotFoundError. See issue #85."""
+
+    log_path = os.path.join(str(tmp_path), "missing_dir", "run.log")
+    assert not os.path.exists(os.path.dirname(log_path))
+
+    utils.init_logging(log_path=log_path, quiet=True)
+
+    assert os.path.exists(log_path)
+
+    # release the file handler so tmp_path cleanup doesn't trip
+    logging.getLogger().handlers = []
 
 
 def test_command_output_does_not_print_to_stdout(capfd):


### PR DESCRIPTION
This fixes #85. When the configured logs folder doesn't exist yet, logging.FileHandler raises FileNotFoundError and crashes the run. The Manager only creates that directory on the live (non-dry) path, so callers like the experiment run path and parallel mode still hit a missing dir. I made init_logging create the parent directory before opening the file handler, since that's the common sink every caller goes through (which I think also covers your "check other paths as well" note). Added a test under test/test_utils.py that fails without the change and passes with it, and black/isort/flake8 are clean. Thanks!